### PR TITLE
Extensions

### DIFF
--- a/src/xAPI/Document/Statement.php
+++ b/src/xAPI/Document/Statement.php
@@ -134,6 +134,9 @@ class Statement extends Document implements JsonSerializable
     public function fixAttachmentLinks($baseUrl)
     {
         if (isset($this->_data['statement']['attachments'])) {
+            if(!is_array($this->_data['statement']['attachments'])){
+                return;
+            }
             foreach ($this->_data['statement']['attachments'] as &$attachment) {
                 if (!isset($attachment['fileUrl'])) {
                     $url = Url::createFromUrl($baseUrl);
@@ -147,6 +150,9 @@ class Statement extends Document implements JsonSerializable
     public function convertExtensionKeysToUnicode()
     {
         if (isset($this->_data['statement']['context']['extensions'])) {
+            if(!is_array($this->_data['statement']['context']['extensions'])){
+                return;
+            }
             foreach ($this->_data['statement']['context']['extensions'] as $extensionKey => $extensionValue) {
                 $newExtensionKey = str_replace('.', '\uFF0E', $extensionKey);
                 $this->_data['statement']['context']['extensions'][$newExtensionKey] = $extensionValue;
@@ -155,6 +161,9 @@ class Statement extends Document implements JsonSerializable
         }
 
         if (isset($this->_data['statement']['result']['extensions'])) {
+            if(!is_array($this->_data['statement']['result']['extensions'])){
+                return;
+            }
             foreach ($this->_data['statement']['result']['extensions'] as $extensionKey => $extensionValue) {
                 $newExtensionKey = str_replace('.', '\uFF0E', $extensionKey);
                 $this->_data['statement']['result']['extensions'][$newExtensionKey] = $extensionValue;
@@ -163,6 +172,9 @@ class Statement extends Document implements JsonSerializable
         }
 
         if (isset($this->_data['statement']['object']['definition']['extensions'])) {
+            if(!is_array($this->_data['statement']['object']['definition']['extensions'])){
+                return;
+            }
             foreach ($this->_data['statement']['object']['definition']['extensions'] as $extensionKey => $extensionValue) {
                 $newExtensionKey = str_replace('.', '\uFF0E', $extensionKey);
                 $this->_data['statement']['object']['definition']['extensions'][$newExtensionKey] = $extensionValue;
@@ -174,6 +186,9 @@ class Statement extends Document implements JsonSerializable
     public function convertExtensionKeysFromUnicode()
     {
         if (isset($this->_data['statement']['context']['extensions'])) {
+            if(!is_array($this->_data['statement']['context']['extensions'])){
+                return;
+            }
             foreach ($this->_data['statement']['context']['extensions'] as $extensionKey => $extensionValue) {
                 $newExtensionKey = str_replace('\uFF0E', '.', $extensionKey);
                 $this->_data['statement']['context']['extensions'][$newExtensionKey] = $extensionValue;
@@ -182,6 +197,9 @@ class Statement extends Document implements JsonSerializable
         }
 
         if (isset($this->_data['statement']['result']['extensions'])) {
+            if(!is_array($this->_data['statement']['result']['extensions'])){
+                return;
+            }
             foreach ($this->_data['statement']['result']['extensions'] as $extensionKey => $extensionValue) {
                 $newExtensionKey = str_replace('\uFF0E', '.', $extensionKey);
                 $this->_data['statement']['result']['extensions'][$newExtensionKey] = $extensionValue;
@@ -190,6 +208,9 @@ class Statement extends Document implements JsonSerializable
         }
 
         if (isset($this->_data['statement']['object']['definition']['extensions'])) {
+            if(!is_array($this->_data['statement']['object']['definition']['extensions'])){
+                return;
+            }
             foreach ($this->_data['statement']['object']['definition']['extensions'] as $extensionKey => $extensionValue) {
                 $newExtensionKey = str_replace('\uFF0E', '.', $extensionKey);
                 $this->_data['statement']['object']['definition']['extensions'][$newExtensionKey] = $extensionValue;
@@ -204,7 +225,7 @@ class Statement extends Document implements JsonSerializable
         // Main activity
         if ((isset($this->_data['statement']['object']['objectType']) && $this->_data['statement']['object']['objectType'] === 'Activity') || !isset($this->_data['statement']['object']['objectType'])) {
             $activity = $this->_data['statement']['object'];
-            
+
             // Sort of a hack - PHP's copy-on-write needs to be executed, otherwise the MongoDB PHP driver
             // overwrites the contents of the variable being passed to the batchInsert call - regardless of
             // whether the variable has been passed by reference or not!
@@ -213,12 +234,12 @@ class Statement extends Document implements JsonSerializable
             // http://php.net/manual/en/mongocollection.batchinsert.php Should behave the same as insert, however, does not
             // https://jira.mongodb.org/browse/PHP-383
             // http://www.phpinternalsbook.com/zvals/memory_management.html#reference-counting-and-copy-on-write
-            // 
+            //
             // TODO: Report bug to Mongo bug tracker
-            // 
+            //
             $activity['DUMMY'] = 'DUMMY';
             unset($activity['DUMMY']);
-            
+
             $activities[] = $activity;
         }
 

--- a/src/xAPI/Validator/V10/Schema/Statements.json
+++ b/src/xAPI/Validator/V10/Schema/Statements.json
@@ -279,7 +279,7 @@
                 "voided": {
                     "type": "boolean"
                 },
-                "attachments": 
+                "attachments":
                 {
                     "type": "array",
                     "items": {"$ref": "Statements.json#/definitions/attachment"}
@@ -394,6 +394,7 @@
             "additionalProperties": false
         },
         "extensions": {
+            "type": "object",
             "patternProperties": {
                 "^[a-zA-Z][a-zA-Z+.-]*:": {
                     "type": ["string", "number", "object"]


### PR DESCRIPTION
@sraka1 please check:

See https://github.com/Brightcookie/lxHive-Internal/issues/50 for details

tldr; we accepting (and store) invalid extension property format (no object) but GET which includes this smt breaks since commit https://github.com/Brightcookie/lxHive/commit/f9b7da3ce7000a7ab1df86d6314bb788e82f497a.

example POST/PUT statements `{ .. extensions: 'invalid' ..}` is accepted, every query GET statements which includes the accepted statement breaks with error 500.

Fix: 
- object required in Json Schema
- added hash type check in document (required for any invalid smts stored already), this is not an elegant fix however the whole file in question needs a makeover imo
