### PR TITLE
resolves #97, command display enhancements

### DIFF
--- a/src/xAPI/Console/BasicTokenCreateCommand.php
+++ b/src/xAPI/Console/BasicTokenCreateCommand.php
@@ -30,6 +30,7 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use API\Service\Auth\Basic as BasicAuthService;
 use API\Service\User as UserService;
@@ -43,10 +44,10 @@ class BasicTokenCreateCommand extends Command
             ->setDescription('Creates a new basic auth token')
             ->setDefinition(
                 new InputDefinition(array(
+                    new InputOption('email', 'e', InputOption::VALUE_OPTIONAL),
                     new InputOption('name', 'na', InputOption::VALUE_OPTIONAL),
                     new InputOption('description', 'd', InputOption::VALUE_OPTIONAL),
                     new InputOption('expiration', 'x', InputOption::VALUE_OPTIONAL),
-                    new InputOption('email', 'e', InputOption::VALUE_OPTIONAL),
                     new InputOption('scopes', 's', InputOption::VALUE_OPTIONAL),
                     new InputOption('key', 'k', InputOption::VALUE_OPTIONAL),
                     new InputOption('secret', 'sc', InputOption::VALUE_OPTIONAL),
@@ -58,15 +59,84 @@ class BasicTokenCreateCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $basicAuthService = new BasicAuthService($this->getSlim());
+        $userService = new UserService($this->getSlim());
+        $userService->fetchAll();
+        $users = [];
+
+        foreach ($userService->getCursor() as $user) {
+            $users[$user->get('email')] = $user;
+        }
+
+        $helper = $this->getHelper('question');
+
+        $output->writeln([
+            '<info>==========================</>',
+            '<info>Create a Basic token</>',
+            '<info>==========================</>',
+            '',
+            '- Creating a basic tokens requires an already registered user (email address match).',
+            '- Use the <info>./X user:create</info> console command for creating users.',
+            '',
+        ]);
+
+        $question = new ConfirmationQuestion('Continue? (y/n) ', false);
+        if (!$helper->ask($input, $output, $question)) {
+            $output->writeln('<error>Process aborted by user.</error>');
+            return 0;
+        }
+
+        if (null === $input->getOption('email')) {
+            $question = new Question('Please enter the email of the associated user: ', '');
+            $question->setAutocompleterValues(array_keys($users));
+
+            $question->setNormalizer(function ($value) {
+                return $value ? trim(strtolower($value)) : '';
+            });
+
+            $question->setValidator(function ($answer) use ($users, $output) {
+                if (!is_string($answer) || empty($answer)) {
+                    throw new \RuntimeException(
+                        'Invalid input!'
+                    );
+                }
+
+                if ('exit' === $answer) {
+                    return $answer;
+                }
+
+                if (!filter_var($answer, FILTER_VALIDATE_EMAIL)) {
+                    throw new \RuntimeException(
+                        'Invalid email address!'
+                    );
+                }
+
+                if (!isset($users[$answer])) {
+                    $output->writeln('  - Hint: Type <info>exit</info> to exit this dialog and return to the console.');
+                    throw new \RuntimeException(
+                        'No user record for "'.$answer.'" found! '
+                    );
+                }
+
+                return $answer;
+            });
+            $question->setMaxAttempts(null);
+
+            $email = $helper->ask($input, $output, $question);
+            if('exit' === $email){
+                $output->writeln('<error>Process aborted by user.</error>');
+                return 0;
+            }
+            $user = $users[$email];
+        }
+
 
         if (null === $input->getOption('name')) {
-            $helper = $this->getHelper('question');
             $question = new Question('Please enter a name: ', 'untitled');
             $name = $helper->ask($input, $output, $question);
         } else {
             $name = $input->getOption('name');
         }
-        
+
         if (null === $input->getOption('description')) {
             $question = new Question('Please enter a description: ', '');
             $description = $helper->ask($input, $output, $question);
@@ -78,27 +148,7 @@ class BasicTokenCreateCommand extends Command
             $question = new Question('Please enter the expiration timestamp for the token (blank == indefinite): ');
             $expiresAt = $helper->ask($input, $output, $question);
         } else {
-            $expiresAt = $input->getOption('expiration');;
-        }
-
-        $userService = new UserService($this->getSlim());
-        $userService->fetchAll();
-        $users = [];
-        foreach ($userService->getCursor() as $user) {
-            $users[$user->getEmail()] = $user;
-        }
-
-        if (null === $input->getOption('email')) {
-            $question = new Question('Please enter enter the e-mail of the associated user: ', '');
-            $question->setAutocompleterValues(array_keys($users));
-            $email = $helper->ask($input, $output, $question);
-            $user = $users[$email];
-        } else {
-            $email = $input->getOption('email');
-            if (!isset($users[$email])) {
-                throw new Exception('Invalid e-mail provided! User does not exist!');
-            }
-            $user = $users[$email];
+            $expiresAt = $input->getOption('expiration');
         }
 
         $userService->fetchAvailablePermissions();
@@ -106,7 +156,7 @@ class BasicTokenCreateCommand extends Command
         foreach ($userService->getCursor() as $scope) {
             $scopesDictionary[$scope->getName()] = $scope;
         }
-        
+
         if (null === $input->getOption('scopes')) {
             $question = new ChoiceQuestion(
                 'Please select which scopes you would like to enable (defaults to super). Separate multiple values with commas (without spaces). If you select super, all other permissions are also inherited: ',


### PR DESCRIPTION
Please check, 

- command notifies that it needs an existing user
- moved user select on top of workflow
- indefinite attempts for email match (without exiting command as before)
- exit option for attempts
- improved validation for user email match

As a sidenote. We're loading the complete user collection just for the autocomplete. This will cause memory issues on large lrsses. I see the need to replace this with a simple enterString->lookupCollection loop in the next release