### PR TITLE
deals with #104, check oauth scope record exists before writing to collection

### DIFF
--- a/src/xAPI/Console/BasicTokenCreateCommand.php
+++ b/src/xAPI/Console/BasicTokenCreateCommand.php
@@ -82,7 +82,7 @@ class BasicTokenCreateCommand extends Command
         // get permissions from user service. Abort if no permissions set
         $userService->fetchAvailablePermissions();
         $hasPermissions = $userService->getCursor()->count();
-        if(!$hasPermissions){
+        if (!$hasPermissions) {
             throw new \RuntimeException(
                 'No oAuth scopes found. Please run command <comment>setup:oauth</comment> first'
             );
@@ -131,7 +131,7 @@ class BasicTokenCreateCommand extends Command
             $question->setMaxAttempts(null);
 
             $email = $helper->ask($input, $output, $question);
-            if('exit' === $email){
+            if ('exit' === $email) {
                 $output->writeln('<error>Process aborted by user.</error>');
                 return 0;
             }

--- a/src/xAPI/Console/BasicTokenCreateCommand.php
+++ b/src/xAPI/Console/BasicTokenCreateCommand.php
@@ -79,6 +79,15 @@ class BasicTokenCreateCommand extends Command
             '',
         ]);
 
+        // get permissions from user service. Abort if no permissions set
+        $userService->fetchAvailablePermissions();
+        $hasPermissions = $userService->getCursor()->count();
+        if(!$hasPermissions){
+            throw new \RuntimeException(
+                'No oAuth scopes found. Please run command <comment>setup:oauth</comment> first'
+            );
+        }
+
         $question = new ConfirmationQuestion('Continue? (y/n) ', false);
         if (!$helper->ask($input, $output, $question)) {
             $output->writeln('<error>Process aborted by user.</error>');
@@ -151,7 +160,6 @@ class BasicTokenCreateCommand extends Command
             $expiresAt = $input->getOption('expiration');
         }
 
-        $userService->fetchAvailablePermissions();
         $scopesDictionary = [];
         foreach ($userService->getCursor() as $scope) {
             $scopesDictionary[$scope->getName()] = $scope;

--- a/src/xAPI/Console/SetupDbCommand.php
+++ b/src/xAPI/Console/SetupDbCommand.php
@@ -27,6 +27,7 @@ namespace API\Console;
 use API\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Yaml\Yaml;
 use Sokil\Mongo\Client;
@@ -45,11 +46,13 @@ class SetupDbCommand extends Command
     {
         $output->writeln('<info>Welcome to the setup of lxHive!</info>');
 
+        // instance name
         $helper = $this->getHelper('question');
-
         $question = new Question('Enter a name for this lxHive instance: ', 'Untitled');
         $name = $helper->ask($input, $output, $question);
+        $output->writeln('<info>x</info> Instance name set to "' .$name.'"!');
 
+        // Mongo connection
         $connectionSuccess = false;
         while (!$connectionSuccess) {
             $question = new Question('Enter the URI of your MongoDB installation (default: "mongodb://127.0.0.1"): ', 'mongodb://127.0.0.1');
@@ -58,26 +61,44 @@ class SetupDbCommand extends Command
             $client = new Client($mongoHostname);
             try {
                 $mongoVersion = $client->getDbVersion();
-                $output->writeln('Connection successful, MongoDB version '.$mongoVersion.'.');
+                $output->writeln('<info>x</info> Connection successful, MongoDB version '.$mongoVersion.'.');
                 $connectionSuccess = true;
             } catch (\MongoConnectionException $e) {
-                $output->writeln('Connection unsuccessful, please try again.');
+                $output->writeln('<error>!</error> Connection unsuccessful, please try again.');
             }
         }
 
+        // Mongo database
         $question = new Question('Enter the name of your MongoDB database (default: "lxHive"): ', 'lxHive');
         $mongoDatabase = $helper->ask($input, $output, $question);
+        $output->writeln('<info>x</info> DB setup complete!');
 
+        // Merge and store config.yml
         $currentConfig = Yaml::parse(file_get_contents(__DIR__.'/../Config/Config.template.yml'));
-
         $mergingArray = ['name' => $name, 'database' => ['host_uri' => $mongoHostname, 'db_name' => $mongoDatabase]];
-
         $newConfig = array_merge($currentConfig, $mergingArray);
-
         $yamlData = Yaml::dump($newConfig);
-
         file_put_contents(__DIR__.'/../Config/Config.yml', $yamlData);
+        $output->writeln('<info>x</info> Configuration saved!');
 
-        $output->writeln('<info>DB setup complete!</info>');
+        // oAuth scopes
+        // @TODO retireve collection name from service
+        $output->writeln('Setting up default OAuth scopes...');
+        $mongo = new \API\Util\MongoClient($newConfig);
+        $collection = $mongo->db->getCollection('authScopes');
+        foreach($newConfig['xAPI']['supported_auth_scopes'] as $scope){
+            $exists = $collection->find()->where('name', $scope['name'])->findOne();
+            if($exists){
+                $output->writeln('  - <comment>skip</comment> scope '.$exists->get('name').' exits already.');
+            } else{
+                $output->writeln('  - <info>new</info> scope '.$scope['name'].' added.');
+            }
+            $document = $collection->createDocument($scope);
+            $document->save();
+        }
+        $output->writeln('<info>x</info> OAuth scopes configured!');
+
+        $output->writeln('<info>Setup complete!</info>');
+
     }
 }

--- a/src/xAPI/Console/SetupDbCommand.php
+++ b/src/xAPI/Console/SetupDbCommand.php
@@ -86,9 +86,9 @@ class SetupDbCommand extends Command
         $output->writeln('Setting up default OAuth scopes...');
         $mongo = new \API\Util\MongoClient($newConfig);
         $collection = $mongo->db->getCollection('authScopes');
-        foreach($newConfig['xAPI']['supported_auth_scopes'] as $scope){
+        foreach ($newConfig['xAPI']['supported_auth_scopes'] as $scope) {
             $exists = $collection->find()->where('name', $scope['name'])->findOne();
-            if($exists){
+            if ($exists) {
                 $output->writeln('  - <comment>skip</comment> scope '.$exists->get('name').' exits already.');
             } else{
                 $output->writeln('  - <info>new</info> scope '.$scope['name'].' added.');

--- a/src/xAPI/Console/SetupOAuthCommand.php
+++ b/src/xAPI/Console/SetupOAuthCommand.php
@@ -46,7 +46,7 @@ class SetupOAuthCommand extends Command
         $oAuthService = new OAuthService($this->getSlim());
         foreach ($this->getSlim()->config('xAPI')['supported_auth_scopes'] as $authScope) {
             $scope = $oAuthService->addScope($authScope['name'], $authScope['description']);
-            if(!$scope){
+            if (!$scope) {
                 $output->writeln('  - <comment>skip</comment> scope '.$authScope['name'].' exits already.');
             } else{
                 $output->writeln('  - <info>new</info> scope '.$authScope['name'].' added.');

--- a/src/xAPI/Console/SetupOAuthCommand.php
+++ b/src/xAPI/Console/SetupOAuthCommand.php
@@ -44,9 +44,13 @@ class SetupOAuthCommand extends Command
         $output->writeln('<info>Setting up default OAuth scopes...</info>');
 
         $oAuthService = new OAuthService($this->getSlim());
-
         foreach ($this->getSlim()->config('xAPI')['supported_auth_scopes'] as $authScope) {
             $scope = $oAuthService->addScope($authScope['name'], $authScope['description']);
+            if(!$scope){
+                $output->writeln('  - <comment>skip</comment> scope '.$authScope['name'].' exits already.');
+            } else{
+                $output->writeln('  - <info>new</info> scope '.$authScope['name'].' added.');
+            }
         }
 
         $output->writeln('<info>OAuth scopes configured!</info>');

--- a/src/xAPI/Console/UserCreateCommand.php
+++ b/src/xAPI/Console/UserCreateCommand.php
@@ -57,7 +57,7 @@ class UserCreateCommand extends Command
         // get permissions from user service. Abort if no permissions set
         $userService->fetchAvailablePermissions();
         $hasPermissions = $userService->getCursor()->count();
-        if(!$hasPermissions){
+        if (!$hasPermissions) {
             throw new \RuntimeException(
                 'No oAuth scopes found. Please run command <comment>setup:oauth</comment> first'
             );

--- a/src/xAPI/Console/UserCreateCommand.php
+++ b/src/xAPI/Console/UserCreateCommand.php
@@ -54,6 +54,15 @@ class UserCreateCommand extends Command
     {
         $userService = new UserService($this->getSlim());
 
+        // get permissions from user service. Abort if no permissions set
+        $userService->fetchAvailablePermissions();
+        $hasPermissions = $userService->getCursor()->count();
+        if(!$hasPermissions){
+            throw new \RuntimeException(
+                'No oAuth scopes found. Please run command <comment>setup:oauth</comment> first'
+            );
+        }
+
         $helper = $this->getHelper('question');
 
         if (null === $input->getOption('email')) {
@@ -70,7 +79,6 @@ class UserCreateCommand extends Command
             $password = $input->getOption('password');
         }
 
-        $userService->fetchAvailablePermissions();
         $permissionsDictionary = [];
         foreach ($userService->getCursor() as $permission) {
             $permissionsDictionary[$permission->getName()] = $permission;

--- a/src/xAPI/Service/ActivityProfile.php
+++ b/src/xAPI/Service/ActivityProfile.php
@@ -86,7 +86,11 @@ class ActivityProfile extends Service
         $cursor->where('activityId', $params->get('activityId'));
 
         if ($params->has('since')) {
-            $since = Util\Date::dateStringToMongoDate($params->get('since'));
+            $date = Util\Date::dateRFC3339($params->get('since'));
+            if(!$date){
+                throw new Exception('"since" parameter is not a valid ISO 8601 timestamp.(Good example: 2015-11-18T12:17:00+00:00), ', Resource::STATUS_NOT_FOUND);
+            }
+            $since = Util\Date::dateTimeToMongoDate($date);
             $cursor->whereGreaterOrEqual('mongoTimestamp', $since);
         }
 

--- a/src/xAPI/Service/ActivityState.php
+++ b/src/xAPI/Service/ActivityState.php
@@ -123,7 +123,11 @@ class ActivityState extends Service
         }
 
         if ($params->has('since')) {
-            $since = Util\Date::dateStringToMongoDate($params->get('since'));
+            $date = Util\Date::dateRFC3339($params->get('since'));
+            if(!$date){
+                throw new Exception('"since" parameter is not a valid ISO 8601 timestamp.(Good example: 2015-11-18T12:17:00+00:00), ', Resource::STATUS_NOT_FOUND);
+            }
+            $since = Util\Date::dateTimeToMongoDate($date);
             $cursor->whereGreaterOrEqual('mongoTimestamp', $since);
         }
 

--- a/src/xAPI/Service/AgentProfile.php
+++ b/src/xAPI/Service/AgentProfile.php
@@ -99,7 +99,11 @@ class AgentProfile extends Service
         $cursor->where('agent', $agent);
 
         if ($params->has('since')) {
-            $since = Util\Date::dateStringToMongoDate($params->get('since'));
+            $date = Util\Date::dateRFC3339($params->get('since'));
+            if(!$date){
+                throw new Exception('"since" parameter is not a valid ISO 8601 timestamp.(Good example: 2015-11-18T12:17:00+00:00), ', Resource::STATUS_NOT_FOUND);
+            }
+            $since = Util\Date::dateTimeToMongoDate($date);
             $cursor->whereGreaterOrEqual('mongoTimestamp', $since);
         }
 
@@ -360,7 +364,7 @@ class AgentProfile extends Service
         // Add to log
         $this->getSlim()->requestLog->addRelation('agentProfiles', $result)->save();
 
-        $result->delete();  
+        $result->delete();
 
         return $this;
     }

--- a/src/xAPI/Service/Auth/OAuth.php
+++ b/src/xAPI/Service/Auth/OAuth.php
@@ -209,7 +209,7 @@ class OAuth extends Service implements AuthInterface
 
         // #104, check if scope document record exists already
         $exists = $collection->find()->where('name', $name)->findOne();
-        if($exists){
+        if ($exists) {
             return false;
         }
 

--- a/src/xAPI/Service/Auth/OAuth.php
+++ b/src/xAPI/Service/Auth/OAuth.php
@@ -207,13 +207,16 @@ class OAuth extends Service implements AuthInterface
     {
         $collection  = $this->getDocumentManager()->getCollection('authScopes');
 
+        // #104, check if scope document record exists already
+        $exists = $collection->find()->where('name', $name)->findOne();
+        if($exists){
+            return false;
+        }
+
         // Set up the Client to be saved
         $scopeDocument = $collection->createDocument();
-
         $scopeDocument->setName($name);
-
         $scopeDocument->setDescription($description);
-
         $scopeDocument->save();
 
         $this->single = true;

--- a/src/xAPI/Service/Statement.php
+++ b/src/xAPI/Service/Statement.php
@@ -331,12 +331,20 @@ class Statement extends Service
 
         // Date based filters
         if ($params->has('since')) {
-            $since = Util\Date::dateStringToMongoDate($params->get('since'));
+            $date = Util\Date::dateRFC3339($params->get('since'));
+            if(!$date){
+                throw new Exception('"since" parameter is not a valid ISO 8601 timestamp.(Good example: 2015-11-18T12:17:00+00:00), ', Resource::STATUS_NOT_FOUND);
+            }
+            $since = Util\Date::dateTimeToMongoDate($date);
             $cursor->whereGreaterOrEqual('mongo_timestamp', $since);
         }
 
         if ($params->has('until')) {
-            $until = Util\Date::dateStringToMongoDate($params->get('until'));
+            $date = Util\Date::dateRFC3339($params->get('until'));
+            if(!$date){
+                throw new Exception('"until" parameter is not a valid ISO 8601 timestamp.(Good example: 2015-11-18T12:17:00+00:00), ', Resource::STATUS_NOT_FOUND);
+            }
+            $until = Util\Date::dateTimeToMongoDate($date);
             $cursor->whereLessOrEqual('mongo_timestamp', $until);
         }
 

--- a/src/xAPI/Util/Date.php
+++ b/src/xAPI/Util/Date.php
@@ -80,4 +80,31 @@ class Date
 
         return $output;
     }
+
+    /**
+     * Attempts to convert a string to a DateTime instance, based on typical (but not all) ISO 8601/RFC 3339 patterns.
+     * Adds also millisecond precision.
+     * @param string $dateString
+     * @param bool $validateStrict is set it checks for precision to at least milliseconds (3 decimal points beyond seconds).
+     *
+     * @return \DateTime|null
+     */
+    public static function dateRFC3339($dateString, $validateStrict = false)
+    {
+        // This is a customized version of the Rfc3339 class in https://github.com/justinrainbow/json-schema.
+        // Tests have shown that this is both a very solid and fast solution.
+        $pattern = '/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d+)?(Z|([+-]\d{2}):?(\d{2}))$/';
+        if (!preg_match($pattern, strtoupper($dateString), $matches)) {
+            return null;
+        }
+        $dateAndTime = $matches[1];
+        if($validateStrict && !$matches[2]){
+            return null;
+        }
+        $microseconds = $matches[2] ?: '.000';
+        $timeZone = 'Z' !== $matches[3] ? $matches[4] . ':' . $matches[5] : '+00:00';
+        $dateTime = \DateTime::createFromFormat('Y-m-d\TH:i:s.uP', $dateAndTime . $microseconds . $timeZone, new \DateTimeZone('UTC'));
+        return $dateTime ?: null;
+    }
+
 }

--- a/src/xAPI/Util/MongoClient.php
+++ b/src/xAPI/Util/MongoClient.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of lxHive LRS - http://lxhive.org/
+ *
+ * Copyright (C) 2015 Brightcookie Pty Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lxHive. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For authorship information, please view the AUTHORS
+ * file that was distributed with this source code.
+ */
+
+namespace API\Util;
+
+use \Sokil\Mongo\Client;
+use API\Resource;
+
+class MongoClient
+{
+    /**
+     * @var \Sokil\Mongo\Client $client mongo client instance
+     */
+    public $client;
+
+    /**
+     * @var \Sokil\Mongo\Database $database mongo database instance
+     */
+    public $db;
+
+    public function __construct($config)
+    {
+        $this->client = new Client($config['database']['host_uri']);
+        $this->db = $this->client->getDatabase($config['database']['db_name']);
+    }
+}

--- a/src/xAPI/Validator/V10/Schema/Statements.json
+++ b/src/xAPI/Validator/V10/Schema/Statements.json
@@ -6,7 +6,7 @@
         "oneOf" : [
             {
                 "type": "array",
-                "maxItems": 0 
+                "maxItems": 0
             },
             {
                 "type": "object",
@@ -40,12 +40,10 @@
                         "type": "boolean"
                     },
                     "since": {
-                        "type": "string",
-                        "format": "date-time"
+                        "type": "string"
                     },
                     "until": {
-                        "type": "string",
-                        "format": "date-time"
+                        "type": "string"
                     },
                     "limit": {
                         "type": "number",
@@ -325,7 +323,7 @@
                                 }
                             ]
                         }
-                        
+
                     }
                 }
             },


### PR DESCRIPTION
Console command looks now like this:

```bash
# first call
./X setup:oauth
Setting up default OAuth scopes...
  - new scope super added.
  - new scope statements/write added.
  - new scope statements/read added.
  - new scope statements/read/mine added.
  - new scope attachments added.
  - new scope state added.
  - new scope profile added.
  - new scope define added.
  - new scope all/read added.
  - new scope all added.
OAuth scopes configured!

# second call
./X setup:oauth
Setting up default OAuth scopes...
  - skip scope super exits already.
  - skip scope statements/write exits already.
  - skip scope statements/read exits already.
  - skip scope statements/read/mine exits already.
  - skip scope attachments exits already.
  - skip scope state exits already.
  - skip scope profile exits already.
  - skip scope define exits already.
  - skip scope all/read exits already.
  - skip scope all exits already.
OAuth scopes configured!

# removed "super" from collection and called again

./X setup:oauth
Setting up default OAuth scopes...
  - new scope super added.
  - skip scope statements/write exits already.
  - skip scope statements/read exits already.
  - skip scope statements/read/mine exits already.
  - skip scope attachments exits already.
  - skip scope state exits already.
  - skip scope profile exits already.
  - skip scope define exits already.
  - skip scope all/read exits already.
  - skip scope all exits already.
OAuth scopes configured!
```