### PR TITLE
basetrait, remove slim dependency, exceptions

### DIFF
--- a/src/xAPI/BaseTrait.php
+++ b/src/xAPI/BaseTrait.php
@@ -23,6 +23,7 @@
  */
 
 namespace API;
+use Interop\Container\ContainerInterface;
 
 trait BaseTrait
 {
@@ -32,46 +33,57 @@ trait BaseTrait
     private $container;
 
     /**
-     * Sets the value of container.
+     * Sets service container.
      *
-     * @param \Slim\Container $container the di container
-     *
+     * @param ContainerInterface $container
      * @return self
      */
-    public function setContainer(\Slim\Container $container)
+    public function setContainer(ContainerInterface $container)
     {
         $this->container = $container;
-
         return $this;
     }
 
-        /**
-     * Gets the value of diContainer.
+    /**
+     * Gets service ontainer.
      *
      * @return \Slim\Container
      */
     public function getContainer()
     {
+        if(!$this->container){
+            throw new \Exception('Basetrait: no container was set.');
+        }
         return $this->container;
     }
 
     /**
-     * Gets the value of storage.
+     * Gets storage service.
      *
      * @return \Storage\AdapterInterface
+     * @throws \Exception
+     * @throws \API\ContainerException
      */
     public function getStorage()
     {
-        return $this->container['storage'];
+        if(!$this->container){
+            throw new \Exception('Basetrait: no container was set.');
+        }
+        return $this->container->get('storage');
     }
 
     /**
-     * Gets the value of log.
+     * Gets log service.
      *
      * @return \Monolog\Monolog
+     * @throws \Exception
+     * @throws \API\ContainerException
      */
     public function getLog()
     {
-        return $this->container['log'];
+        if(!$this->container){
+            throw new \Exception('Basetrait: no container was set.');
+        }
+        return $this->container->get('log');
     }
 }

--- a/tests/src/xAPI/BaseTraitTest.php
+++ b/tests/src/xAPI/BaseTraitTest.php
@@ -1,0 +1,60 @@
+<?php
+namespace Tests\API;
+
+use Tests\TestCase;
+
+use API\Container;
+use API\ContainerException;
+use API\BaseTrait;
+
+class BasetraitTest extends TestCase
+{
+    use BaseTrait;
+
+    public function testSetContainer()
+    {
+        $container = new Container();
+        $container['pi'] = pi();
+        $this->setContainer($container);
+
+        $services = $this->getContainer();
+        $this->assertEquals(pi(), $container->get('pi'));
+    }
+
+    public function testInvalidContainerType()
+    {
+        $threw = false;
+        try {
+            $services = $this->setContainer(array());
+        } catch (\Throwable $t) {
+            $threw = 'PHP 7.x';
+        } catch (\Exception $e) {
+            $threw = 'PHP 5.x';
+        }
+        $this->assertNotFalse($threw);
+    }
+
+    public function testNoContainer()
+    {
+        $this->expectException(\Exception::class);
+        $services = $this->getContainer();
+    }
+
+    public function testNoStorageContainer()
+    {
+        $container = new Container();
+        $this->setContainer($container);
+
+        $this->expectException(ContainerException::class);
+        $services = $this->getStorage();
+    }
+
+    public function testNoLogContainer()
+    {
+        $container = new Container();
+
+        $this->setContainer($container);
+        $this->expectException(ContainerException::class);
+        $services = $this->getStorage();
+    }
+}


### PR DESCRIPTION
see tests and changes. The changes were necessary and  they illustrate how problematic overhead due to further abstraction of container injection is. I actually vote for getting rid of the BaseTrait class altogether. It leads to lines like 
```
$documentResult = $this->getStorage()->getAgentProfileStorage()->post($params, $rawBody);
// Basetrait continer get/set is called at least 2 times in this line.
// Typically this line gets called below Bootstrap->Router->Parser->Validator->Service so there is more juggling
```
It would be more simple and transparent to set a protected $container in the actual class constructor.

https://en.wikipedia.org/wiki/God_object
