### PR TITLE
Development

### DIFF
--- a/src/xAPI/Admin/AdminException.php
+++ b/src/xAPI/Admin/AdminException.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * This file is part of lxHive LRS - http://lxhive.org/
+ *
+ * Copyright (C) 2017 Brightcookie Pty Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lxHive. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For authorship information, please view the AUTHORS
+ * file that was distributed with this source code.
+ */
+namespace API\Admin;
+
+/**
+ * Exceptions for Admin API
+ */
+class AdminException extends \Exception
+{
+
+}

--- a/src/xAPI/Admin/AdminException.php
+++ b/src/xAPI/Admin/AdminException.php
@@ -25,7 +25,7 @@ namespace API\Admin;
 /**
  * Exceptions for Admin API
  */
-class AdminException extends \Exception
+class AdminException extends \RunTimeException
 {
 
 }

--- a/src/xAPI/Admin/AdminException.php
+++ b/src/xAPI/Admin/AdminException.php
@@ -27,5 +27,4 @@ namespace API\Admin;
  */
 class AdminException extends \RunTimeException
 {
-
 }

--- a/src/xAPI/Admin/Setup.php
+++ b/src/xAPI/Admin/Setup.php
@@ -82,7 +82,7 @@ class Setup
     public function loadYaml($yml)
     {
         $file = $this->locateYaml($yml);
-        if(false === $file){
+        if (false === $file) {
             throw new AdminException('File `'.$yml.'` not found.');
         }
 
@@ -98,7 +98,7 @@ class Setup
             throw new AdminException('Error parsing data from file `'.$yml.'`');
         }
 
-        if(!$data){
+        if (!$data) {
             throw new AdminException('Error parsing data from file `'.$yml.'`: Empty data.');
         }
 
@@ -115,7 +115,7 @@ class Setup
      */
     public function installYaml($yml, array $mergeData = [])
     {
-        if($this->locateYaml($yml)){
+        if ($this->locateYaml($yml)) {
             throw new AdminException('File `'.$yml.'` exists already. The LRS configuration would be overwritten. To restore the defaults you must manually remove the file first.');
         }
 

--- a/src/xAPI/Admin/Setup.php
+++ b/src/xAPI/Admin/Setup.php
@@ -185,43 +185,4 @@ class Setup
             $scope = $oAuthService->addScope($authScope['name'], $authScope['description']);
         }
     }
-
-    /**
-     * Validate password
-     * @param string $str
-     *
-     * @return void
-     * @throws \RuntimeException
-     */
-    public function validatePassword(string $str)
-    {
-        $errors = [];
-        $length = 8;
-
-        if (strlen($str) < $length) {
-            $errors[] = 'Must have at least '.$length.' characters';
-        }
-
-        if (!preg_match('/[0-9]+/', $str)) {
-            $errors[] = 'Must include at least one number.';
-        }
-
-        if (!preg_match('/[a-zA-Z]+/', $str)) {
-            $errors[] = 'Must include at least one letter.';
-        }
-
-        if( !preg_match('/[A-Z]+/', $str) ) {
-            $errors[] = 'Must include at least one CAPS!';
-        }
-
-        if( !preg_match('/\W+/', $str) ) {
-            $errors[] = 'Must include at least one symbol!';
-        }
-
-        if(!empty($errors)) {
-            throw new \RuntimeException(json_encode($errors));
-        }
-
-    }
-
 }

--- a/src/xAPI/Admin/User.php
+++ b/src/xAPI/Admin/User.php
@@ -51,16 +51,42 @@ class User extends Admin
     }
 
     /**
+     * Fetch all permissions from Mongo
+     * @return array collection of permissions with their name as key
+     */
+    public function fetchAvailablePermissionNames()
+    {
+        //TODO this method will be obsolete if we remove the authScopes collection
+        $service = new UserService($this->getContainer());
+        $document = $service->fetchAvailablePermissionNames();
+        return current($document->getCursor()->toArray())->values;
+    }
+
+    /**
      * Add a user record
      * @param string $email
      * @param string $password
      * @param array $selectedPermissions selected scope permission records
      * @return stdClass Mongo user record
+     * @throws \API\RuntimeException
      */
     public function addUser($email, $password, $selectedPermissions)
     {
-        $userService = new UserService($this->getContainer());
-        $user = $userService->addUser($email, $password, $selectedPermissions);
+        $v = new Validator();
+        $v->validateEmail($email);
+        $v->validatePassword($password);
+
+        $service = new UserService($this->getContainer());
+
+        // fetch available permissions and compare
+        $result = $service->fetchPermissionsByNames($selectedPermissions);
+
+        $permissions = $result->getCursor()->toArray();
+        if (count($permissions) !== count($selectedPermissions)) {
+            throw new AdminException('Invalid permissions: '.json_encode($selectedPermissions));
+        }
+echo 'HERE';
+        $user = $service->addUser($email, $password, $permissions);
 
         return $user;
     }

--- a/src/xAPI/Admin/User.php
+++ b/src/xAPI/Admin/User.php
@@ -70,23 +70,22 @@ class User extends Admin
      * @return stdClass Mongo user record
      * @throws \API\RuntimeException
      */
-    public function addUser($email, $password, $selectedPermissions)
+    public function addUser($name, $description, $email, $password, $selectedPermissions)
     {
         $v = new Validator();
+        $v->validateName($name);
         $v->validateEmail($email);
         $v->validatePassword($password);
 
-        $service = new UserService($this->getContainer());
-
         // fetch available permissions and compare
+        $service = new UserService($this->getContainer());
         $result = $service->fetchPermissionsByNames($selectedPermissions);
-
         $permissions = $result->getCursor()->toArray();
         if (count($permissions) !== count($selectedPermissions)) {
             throw new AdminException('Invalid permissions: '.json_encode($selectedPermissions));
         }
-echo 'HERE';
-        $user = $service->addUser($email, $password, $permissions);
+
+        $user = $service->addUser($name, $description, $email, $password, $permissions);
 
         return $user;
     }

--- a/src/xAPI/Admin/Validator.php
+++ b/src/xAPI/Admin/Validator.php
@@ -59,7 +59,7 @@ class Validator
             $errors[] = 'Must have at least '.$length.' characters';
         }
 
-        if(!empty($errors)) {
+        if (!empty($errors)) {
             throw new AdminException(json_encode($errors));
         }
     }
@@ -88,18 +88,17 @@ class Validator
             $errors[] = 'Must include at least one letter.';
         }
 
-        if( !preg_match('/[A-Z]+/', $str) ) {
+        if (!preg_match('/[A-Z]+/', $str)) {
             $errors[] = 'Must include at least one CAPS!';
         }
 
-        if( !preg_match('/\W+/', $str) ) {
+        if (!preg_match('/\W+/', $str)) {
             $errors[] = 'Must include at least one symbol!';
         }
 
-        if(!empty($errors)) {
+        if (!empty($errors)) {
             throw new AdminException(json_encode($errors));
         }
-
     }
 
     /**
@@ -126,16 +125,16 @@ class Validator
      */
     public function validateXapiPermissions(array $perms, array $available)
     {
-        if(empty($perms)) {
+        if (empty($perms)) {
             throw new AdminException('Permissions cannot be empty.');
         }
 
-        if(empty($available)) {
+        if (empty($available)) {
             throw new AdminException('Available permissions cannot be empty.');
         }
 
         foreach ($perms as $p) {
-            if(!in_array($p, $available)) {
+            if (!in_array($p, $available)) {
                 throw new AdminException('Invalid permission');
             }
         }

--- a/src/xAPI/Admin/Validator.php
+++ b/src/xAPI/Admin/Validator.php
@@ -44,6 +44,27 @@ class Validator
     }
 
     /**
+     * Validate name param
+     * @param string $str
+     *
+     * @return void
+     * @throws AdminException
+     */
+    public function validateName(string $str)
+    {
+        $errors = [];
+        $length = 4;
+
+        if (!$str || strlen($str) < $length) {
+            $errors[] = 'Must have at least '.$length.' characters';
+        }
+
+        if(!empty($errors)) {
+            throw new AdminException(json_encode($errors));
+        }
+    }
+
+    /**
      * Validate password
      * @param string $str
      *

--- a/src/xAPI/Admin/Validator.php
+++ b/src/xAPI/Admin/Validator.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of lxHive LRS - http://lxhive.org/
+ *
+ * Copyright (C) 2017 Brightcookie Pty Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lxHive. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For authorship information, please view the AUTHORS
+ * file that was distributed with this source code.
+ */
+
+namespace API\Admin;
+
+use API\Bootstrap;
+use API\Config;
+
+/**
+ * Admin validator functions
+ */
+class Validator
+{
+
+    /**
+     * constructor
+     */
+    public function __construct()
+    {
+        if (!Bootstrap::mode()) {
+            $bootstrap = Bootstrap::factory(Bootstrap::Config);
+        }
+    }
+
+    /**
+     * Validate password
+     * @param string $str
+     *
+     * @return void
+     * @throws AdminException
+     */
+    public function validatePassword(string $str)
+    {
+        $errors = [];
+        $length = 8;
+
+        if (strlen($str) < $length) {
+            $errors[] = 'Must have at least '.$length.' characters';
+        }
+
+        if (!preg_match('/[0-9]+/', $str)) {
+            $errors[] = 'Must include at least one number.';
+        }
+
+        if (!preg_match('/[a-zA-Z]+/', $str)) {
+            $errors[] = 'Must include at least one letter.';
+        }
+
+        if( !preg_match('/[A-Z]+/', $str) ) {
+            $errors[] = 'Must include at least one CAPS!';
+        }
+
+        if( !preg_match('/\W+/', $str) ) {
+            $errors[] = 'Must include at least one symbol!';
+        }
+
+        if(!empty($errors)) {
+            throw new AdminException(json_encode($errors));
+        }
+
+    }
+
+    /**
+     * Validate email address
+     * @param string $email
+     *
+     * @return void
+     * @throws AdminException
+     */
+    public function validateEmail(string $email)
+    {
+        if (!filter_var($email, \FILTER_VALIDATE_EMAIL)) {
+            throw new AdminException('Invalid email address!');
+        }
+    }
+
+    /**
+     * Validate xAPI permission scopes
+     * @param array $perms array of strings: permissions to check
+     * @param array $available array of strings: available permissions to check against
+     *
+     * @return void
+     * @throws AdminException
+     */
+    public function validateXapiPermissions(array $perms, array $available)
+    {
+        if(empty($perms)) {
+            throw new AdminException('Permissions cannot be empty.');
+        }
+
+        if(empty($available)) {
+            throw new AdminException('Available permissions cannot be empty.');
+        }
+
+        foreach ($perms as $p) {
+            if(!in_array($p, $available)) {
+                throw new AdminException('Invalid permission');
+            }
+        }
+    }
+}

--- a/src/xAPI/Config/Templates/UnitTest.yml
+++ b/src/xAPI/Config/Templates/UnitTest.yml
@@ -1,0 +1,1 @@
+description: 'A test yml file for unit testing'

--- a/src/xAPI/Console/SetupCommand.php
+++ b/src/xAPI/Console/SetupCommand.php
@@ -63,7 +63,7 @@ class SetupCommand extends SymfonyCommand
     {
         // 1. check config
         $bootstrapper = Bootstrap::factory(Bootstrap::None);
-        if ($this->getSetup()->checkYaml('Config.yml')) {
+        if ($this->getSetup()->locateYaml('Config.yml')) {
             throw new \Exception('A `Config.yml` file exists already. The LRS configuration would be overwritten. To restore the defaults you must manually remove the file first.');
         }
 
@@ -94,10 +94,10 @@ class SetupCommand extends SymfonyCommand
         $mergeConfig = ['name' => $name, 'storage' => ['in_use' => 'Mongo', 'Mongo' => ['host_uri' => $mongoHostname, 'db_name' => $mongoDatabase]]];
         $this->getSetup()->installYaml('Config.yml', $mergeConfig);
 
-        if (!$this->getSetup()->checkYaml('Config.production.yml')) {
+        if (!$this->getSetup()->locateYaml('Config.production.yml')) {
             $this->getSetup()->installYaml('Config.production.yml');
         }
-        if (!$this->getSetup()->checkYaml('Config.development.yml')) {
+        if (!$this->getSetup()->locateYaml('Config.development.yml')) {
             $this->getSetup()->installYaml('Config.development.yml');
         }
 

--- a/src/xAPI/Console/UserCreateCommand.php
+++ b/src/xAPI/Console/UserCreateCommand.php
@@ -56,17 +56,14 @@ class UserCreateCommand extends Command
     {
         $userAdmin = new UserAdministration($this->getContainer());
         $helper = $this->getHelper('question');
-        $admin = new Admin\Setup();
+        $validator = new Admin\Validator();
 
         // 1. Email
         if (null === $input->getOption('email')) {
             $question = new Question('Please enter an e-mail: ', 'untitled');
             $question->setMaxAttempts(null);
-            $question->setValidator(function ($answer) {
-                if (!filter_var($answer, FILTER_VALIDATE_EMAIL)) {
-                    throw new \RuntimeException('Invalid email address!');
-                }
-
+            $question->setValidator(function ($answer) use ($validator) {
+                $validator->validateEmail($answer);
                 return $answer;
             });
             $email = $helper->ask($input, $output, $question);
@@ -78,8 +75,8 @@ class UserCreateCommand extends Command
         if (null === $input->getOption('password')) {
             $question = new Question('Please enter a password: ', '');
             $question->setMaxAttempts(null);
-            $question->setValidator(function ($answer) use ($admin) {
-                $admin->validatePassword($answer);
+            $question->setValidator(function ($answer) use ($validator) {
+                $validator->validatePassword($answer);
                 return $answer;
             });
             $password = $helper->ask($input, $output, $question);
@@ -88,29 +85,23 @@ class UserCreateCommand extends Command
         }
 
         // 3. Permissions
-        $permissionsDictionary = $userAdmin->fetchAvailablePermissions();
-        $permissions = array_keys($permissionsDictionary);
 
+        $available = $userAdmin->fetchAvailablePermissionNames();
         if (null === $input->getOption('permissions')) {
             $question = new ChoiceQuestion(
                 'Please select which permissions you would like to enable (defaults to super). Separate multiple values with commas (without spaces). If you select super, all other permissions are also inherited: ',
-                $permissions,
+                $available,
                 '0'
             );
             $question->setMultiselect(true);
             $question->setMaxAttempts(null);
             // validation done by helper
-            $selectedPermissions = $helper->ask($input, $output, $question);
+            $selected = $helper->ask($input, $output, $question);
         } else {
-            $selectedPermissions = explode(',', $input->getOption('permissions'));
+            $selected = explode(',', $input->getOption('permissions'));
         }
 
-        $selected = [];
-        foreach ($selectedPermissions as $name) {
-            $selected[] = $permissionsDictionary[$name];
-        }
-
-        $user = $userAdmin->addUser($email, $password, $selected);
+        $user = $userAdmin->addUser($email, $password, array_unique($selected));
         $text = json_encode($user, JSON_PRETTY_PRINT);
 
         $output->writeln('<info>User successfully created!</info>');

--- a/src/xAPI/Console/UserCreateCommand.php
+++ b/src/xAPI/Console/UserCreateCommand.php
@@ -58,54 +58,56 @@ class UserCreateCommand extends Command
         $helper = $this->getHelper('question');
         $validator = new Admin\Validator();
 
-        // 1. Email
-        if (null === $input->getOption('email')) {
-            $question = new Question('Please enter an e-mail: ', 'untitled');
-            $question->setMaxAttempts(null);
-            $question->setValidator(function ($answer) use ($validator) {
-                $validator->validateEmail($answer);
-                return $answer;
-            });
-            $email = $helper->ask($input, $output, $question);
-        } else {
-            $email = $input->getOption('email');
-        }
+        // 1. Name
+        $question = new Question('Please enter a name: ', '');
+        $question->setMaxAttempts(null);
+        $question->setValidator(function ($answer) use ($validator) {
+            $validator->validateName($answer);
+            return $answer;
+        });
+        $name = $helper->ask($input, $output, $question);
 
-        // 2. Password
-        if (null === $input->getOption('password')) {
-            $question = new Question('Please enter a password: ', '');
-            $question->setMaxAttempts(null);
-            $question->setValidator(function ($answer) use ($validator) {
-                $validator->validatePassword($answer);
-                return $answer;
-            });
-            $password = $helper->ask($input, $output, $question);
-        } else {
-            $password = $input->getOption('password');
-        }
+        // 2. Description
+        $question = new Question('Please enter a description: ', '');
+        $description = $helper->ask($input, $output, $question);
 
-        // 3. Permissions
+        // 3. Email
+        $question = new Question('Please enter an e-mail: ', '');
+        $question->setMaxAttempts(null);
+        $question->setValidator(function ($answer) use ($validator) {
+            $validator->validateEmail($answer);
+            return $answer;
+        });
+        $email = $helper->ask($input, $output, $question);
 
+        // 4. Password
+        $question = new Question('Please enter a password: ', '');
+        $question->setMaxAttempts(null);
+        $question->setValidator(function ($answer) use ($validator) {
+            $validator->validatePassword($answer);
+            return $answer;
+        });
+        $password = $helper->ask($input, $output, $question);
+
+        // 5. Permissions
         $available = $userAdmin->fetchAvailablePermissionNames();
-        if (null === $input->getOption('permissions')) {
-            $question = new ChoiceQuestion(
-                'Please select which permissions you would like to enable (defaults to super). Separate multiple values with commas (without spaces). If you select super, all other permissions are also inherited: ',
-                $available,
-                '0'
-            );
-            $question->setMultiselect(true);
-            $question->setMaxAttempts(null);
-            // validation done by helper
-            $selected = $helper->ask($input, $output, $question);
-        } else {
-            $selected = explode(',', $input->getOption('permissions'));
-        }
+        $question = new ChoiceQuestion(
+            'Please select which permissions you would like to enable (defaults to super). Separate multiple values with commas (without spaces). If you select super, all other permissions are also inherited: ',
+            $available,
+            '0'
+        );
+        $question->setMultiselect(true);
+        $question->setMaxAttempts(null);
+        $permissions = $helper->ask($input, $output, $question);// validation by ChoiceQuestion
 
-        $user = $userAdmin->addUser($email, $password, array_unique($selected));
+        // 6. add record
+        $permissions = array_unique($permissions);
+        $user = $userAdmin->addUser($name, $description, $email, $password, $permissions);
         $text = json_encode($user, JSON_PRETTY_PRINT);
 
         $output->writeln('<info>User successfully created!</info>');
         $output->writeln('<info>Info:</info>');
         $output->writeln($text);
     }
+
 }

--- a/src/xAPI/Service/Auth/Basic.php
+++ b/src/xAPI/Service/Auth/Basic.php
@@ -137,6 +137,8 @@ class Basic extends Service implements AuthInterface
 
         $defaultParams = new Util\Collection([
             'user' => [
+                'name' => 'anonymous',
+                'description' => '',
                 'password' => 'password',
                 'permissions' => [
                     'all',
@@ -177,7 +179,7 @@ class Basic extends Service implements AuthInterface
 
         // This is ugly, remove this!
         $userService = new UserService($this->getContainer());
-        $user = $userService->addUser($params->get('user')['email'], $params->get('user')['password'], $permissionDocuments);
+        $user = $userService->addUser($params->get('user')['name'], $params->get('user')['description'], $params->get('user')['email'], $params->get('user')['password'], $permissionDocuments);
 
         $accessTokenDocument = $this->addToken($params->get('name'), $params->get('description'), $expiresAt, $user, $scopeDocuments);
 

--- a/src/xAPI/Service/User.php
+++ b/src/xAPI/Service/User.php
@@ -131,6 +131,20 @@ class User extends Service
         return $documentResult;
     }
 
+    public function fetchPermissionsByNames($names)
+    {
+        $documentResult = $this->getStorage()->getAuthScopesStorage()->findByNames($names);
+
+        return $documentResult;
+    }
+
+    public function fetchAvailablePermissionNames()
+    {
+        $documentResult = $this->getStorage()->getAuthScopesStorage()->getNames();
+
+        return $documentResult;
+    }
+
     public function fetchAvailablePermissions()
     {
         $documentResult = $this->getStorage()->getUserStorage()->fetchAvailablePermissions();

--- a/src/xAPI/Service/User.php
+++ b/src/xAPI/Service/User.php
@@ -114,9 +114,9 @@ class User extends Service
         return $userDocument;
     }
 
-    public function addUser($email, $password, $permissions)
+    public function addUser($name, $description, $email, $password, $permissions)
     {
-        $userDocument = $this->getStorage()->getUserStorage()->addUser($email, $password, $permissions);
+        $userDocument = $this->getStorage()->getUserStorage()->addUser($name, $description, $email, $password, $permissions);
 
         $this->single = true;
         $this->cursor = [$userDocument];

--- a/src/xAPI/Storage/Adapter/Mongo.php
+++ b/src/xAPI/Storage/Adapter/Mongo.php
@@ -159,6 +159,29 @@ class Mongo implements AdapterInterface
     }
 
     /**
+     * Fetches distinct documents.
+     *
+     * @param string $collection Name of collection
+     * @param array|Expression $filter The filter to fetch the documents by
+     * @param array $options
+     * @return DocumentResult Result of fetch
+     */
+    public function distinct($collection, $field, $filter = [], $options = [])
+    {
+        // query doesn't accept empty array: [MongoDB\Driver\Exception\RuntimeException] "query" had the wrong type. Expected object or null, found array
+        $command = new Command([
+            'distinct' => $collection,
+            'key' => $field,
+            'query' => (empty($filter)) ? null : $filter,
+            'options' => $options,
+        ]);
+
+        $cursor = $this->getClient()->executeCommand($this->databaseName, $command);
+
+        return $cursor;
+    }
+
+    /**
      * Fetches documents.
      *
      * @param string $collection Name of collection

--- a/src/xAPI/Storage/Adapter/Mongo/AuthScopes.php
+++ b/src/xAPI/Storage/Adapter/Mongo/AuthScopes.php
@@ -53,4 +53,29 @@ class AuthScopes extends Provider implements AuthScopesInterface
 
         return $documentResult;
     }
+
+    public function findByNames($names, $options = [])
+    {
+        $storage = $this->getContainer()['storage'];
+        $cursor = $storage->find(self::COLLECTION_NAME, [
+            'name' => ['$in' => $names]
+        ], $options);
+
+        $documentResult = new \API\Storage\Query\DocumentResult();
+        $documentResult->setCursor($cursor);
+
+        return $documentResult;
+    }
+
+    public function getNames()
+    {
+        $storage = $this->getContainer()['storage'];
+        $cursor = $storage->distinct(self::COLLECTION_NAME, 'name');
+
+        $documentResult = new \API\Storage\Query\DocumentResult();
+        $documentResult->setCursor($cursor);
+
+        return $documentResult;
+    }
+
 }

--- a/src/xAPI/Storage/Adapter/Mongo/User.php
+++ b/src/xAPI/Storage/Adapter/Mongo/User.php
@@ -56,13 +56,15 @@ class User extends Provider implements UserInterface
         return $result;
     }
 
-    public function addUser($email, $password, $permissions)
+    public function addUser($name, $description, $email, $password, $permissions)
     {
         $storage = $this->getContainer()['storage'];
 
         // Set up the User to be saved
         $userDocument = new \API\Document\Generic();
 
+        $userDocument->setName($name);
+        $userDocument->setDescription($description);
         $userDocument->setEmail($email);
 
         $passwordHash = sha1($password);
@@ -75,6 +77,9 @@ class User extends Provider implements UserInterface
             $permissionIds[] = $permission->_id;
             $userDocument->setPermissionIds($permissionIds);
         }
+
+        $now = new \DateTime();
+        $userDocument->setCreatedAt(\API\Util\Date::dateTimeToMongoDate($now));
 
         $storage->insertOne(self::COLLECTION_NAME, $userDocument);
 

--- a/src/xAPI/Storage/Query/UserInterface.php
+++ b/src/xAPI/Storage/Query/UserInterface.php
@@ -30,7 +30,7 @@ interface UserInterface
 
     public function findById($id);
 
-    public function addUser($email, $password, $permissions);
+    public function addUser($name, $user, $email, $password, $permissions);
 
     public function fetchAll();
 

--- a/tests/Unit/Issue91/StreamContextTest.php
+++ b/tests/Unit/Issue91/StreamContextTest.php
@@ -12,8 +12,7 @@ class StreamContextTest extends TestCase
 
     protected function setUp()
     {
-
-        if(!class_exists('\Tests\Config')){
+        if (!class_exists('\Tests\Config')) {
             $this->markTestIncomplete(
               'class \Tests\Config does not exist or is invalid.'
             );

--- a/tests/src/xAPI/Admin/SetupTest.php
+++ b/tests/src/xAPI/Admin/SetupTest.php
@@ -5,9 +5,163 @@ use Tests\TestCase;
 
 use API\Bootstrap;
 use API\Admin\Setup;
+use API\Admin\AdminException;
 
 class SetupTest extends TestCase
 {
+    const ConfigDir = './src/xAPI/Config/';
+
+    public static function setUpBeforeClass()
+    {
+        if(!is_writable(self::ConfigDir)) {
+            throw new \RuntimeException(self::ConfigDir.' is not a writable directory.');
+        }
+    }
+
+    // cleanup after tests
+    public function tearDown()
+    {
+        if(file_exists(self::ConfigDir.'UnitTest.yml')) {
+            unlink(self::ConfigDir.'UnitTest.yml');
+        }
+    }
+
+    ////
+    // Config yml manager
+    ////
+
+    public function testLocateYaml()
+    {
+        // NotFound
+        $admin = new Setup();
+        $file = $admin->locateYaml('UnitTest.yml');
+        $this->assertFalse($file);
+
+        // Found
+        touch(self::ConfigDir.'UnitTest.yml');
+        $file = $admin->locateYaml('UnitTest.yml');
+        $this->assertStringEndsWith('/UnitTest.yml', $file);
+    }
+
+    /**
+     * @depends testLocateYaml
+     */
+    public function testInstallYaml()
+    {
+        $admin = new Setup();
+        $data = $admin->installYaml('UnitTest.yml');
+
+        $this->assertFileExists(self::ConfigDir.'UnitTest.yml');
+        $this->assertTrue(is_array($data));
+        $this->assertGreaterThan(0, count($data));
+    }
+
+    /**
+     * @depends testLocateYaml
+     */
+    public function testInstallYamlInvalidTemplate()
+    {
+        $admin = new Setup();
+
+        $this->expectException(AdminException::class);
+        $data = $admin->installYaml('InvalidUnitTest.yml');
+    }
+
+    /**
+     * @depends testLocateYaml
+     */
+    public function testInstallYamlMergeData()
+    {
+        $admin = new Setup();
+        $now = time();
+
+        $data = $admin->installYaml('UnitTest.yml', ['now' => $now ]);
+        $this->assertArrayHasKey('now', $data);
+        $this->assertEquals($data['now'], $now);
+    }
+
+    /**
+     * @depends testInstallYaml
+     */
+    public function testLoadYaml()
+    {
+        $admin = new Setup();
+
+        $admin->installYaml('UnitTest.yml');
+        $data = $admin->loadYaml('UnitTest.yml');
+        $this->assertTrue(is_array($data));
+        $this->assertGreaterThan(0, count($data));
+    }
+
+    /**
+     * @depends testInstallYaml
+     */
+    public function testLoadYamlNotFound()
+    {
+        $admin = new Setup();
+
+        $this->expectException(AdminException::class);
+        $admin->loadYaml('InvalidUnitTest.yml');
+    }
+
+    /**
+     * @depends testInstallYaml
+     */
+    public function testLoadYamlInvalidJson()
+    {
+        $admin = new Setup();
+
+        file_put_contents(self::ConfigDir.'UnitTest.yml', '{invalid yml');
+        $this->assertFileExists(self::ConfigDir.'UnitTest.yml');
+
+        $this->expectException(AdminException::class);
+        $data = $admin->loadYaml('UnitTest.yml');
+    }
+
+    /**
+     * @depends testInstallYaml
+     */
+    public function testLoadYamlEmptyData()
+    {
+        $admin = new Setup();
+
+        file_put_contents(self::ConfigDir.'UnitTest.yml', '');
+        $this->assertFileExists(self::ConfigDir.'UnitTest.yml');
+
+        $this->expectException(AdminException::class);
+        $data = $admin->loadYaml('UnitTest.yml');
+    }
+
+    /**
+     * @depends testInstallYaml
+     */
+    public function testUpdateYaml()
+    {
+        $admin = new Setup();
+        $now = time();
+
+        $admin->installYaml('UnitTest.yml', ['now' => 'a string' ]);
+        $data = $admin->updateYaml('UnitTest.yml', ['now' => $now ]);
+
+        $this->assertArrayHasKey('now', $data);
+        $this->assertEquals($data['now'], $now);
+    }
+
+    /**
+     * @depends testInstallYaml
+     */
+    public function testUpdateYamlNotFound()
+    {
+        $admin = new Setup();
+        $now = time();
+
+        $this->expectException(AdminException::class);
+        $data = $admin->updateYaml('InvalidUnitTest.yml', ['now' => $now ]);
+    }
+
+    ////
+    // Misc
+    ////
 
     public function testvalidatePassword()
     {

--- a/tests/src/xAPI/Admin/SetupTest.php
+++ b/tests/src/xAPI/Admin/SetupTest.php
@@ -13,7 +13,7 @@ class SetupTest extends TestCase
 
     public static function setUpBeforeClass()
     {
-        if(!is_writable(self::ConfigDir)) {
+        if (!is_writable(self::ConfigDir)) {
             throw new \RuntimeException(self::ConfigDir.' is not a writable directory.');
         }
     }
@@ -21,7 +21,7 @@ class SetupTest extends TestCase
     // cleanup after tests
     public function tearDown()
     {
-        if(file_exists(self::ConfigDir.'UnitTest.yml')) {
+        if (file_exists(self::ConfigDir.'UnitTest.yml')) {
             unlink(self::ConfigDir.'UnitTest.yml');
         }
     }
@@ -158,5 +158,4 @@ class SetupTest extends TestCase
         $this->expectException(AdminException::class);
         $data = $admin->updateYaml('InvalidUnitTest.yml', ['now' => $now ]);
     }
-
 }

--- a/tests/src/xAPI/Admin/SetupTest.php
+++ b/tests/src/xAPI/Admin/SetupTest.php
@@ -159,19 +159,4 @@ class SetupTest extends TestCase
         $data = $admin->updateYaml('InvalidUnitTest.yml', ['now' => $now ]);
     }
 
-    ////
-    // Misc
-    ////
-
-    public function testvalidatePassword()
-    {
-        $admin = new Setup();
-        $admin->validatePassword('ValidPass999!');
-
-        $this->expectException(\RuntimeException::class);
-        $admin->validatePassword('Val'); // too short
-        $admin->validatePassword('ValidPass!'); // requires number
-        $admin->validatePassword('ValidPass999'); // requires non alphaNumeric
-    }
-
 }

--- a/tests/src/xAPI/Admin/ValidatorTest.php
+++ b/tests/src/xAPI/Admin/ValidatorTest.php
@@ -9,7 +9,6 @@ use API\Admin\AdminException;
 
 class ValidatorTest extends TestCase
 {
-
     public function testvalidateName()
     {
         $v = new Validator();
@@ -60,5 +59,4 @@ class ValidatorTest extends TestCase
         $v->validateXapiPermissions(['invalid'], $available);
         $v->validateXapiPermissions(['invalid', 'statements/read'], $available);
     }
-
 }

--- a/tests/src/xAPI/Admin/ValidatorTest.php
+++ b/tests/src/xAPI/Admin/ValidatorTest.php
@@ -10,6 +10,20 @@ use API\Admin\AdminException;
 class ValidatorTest extends TestCase
 {
 
+    public function testvalidateName()
+    {
+        $v = new Validator();
+        $v->validateName('valid');
+        $v->validateName('valid whitespace');
+        $v->validateName('valid.chars');
+
+        $this->expectException(AdminException::class);
+        $v->validateName('');
+        $v->validateName(false); // empty space
+        $v->validateName(2);
+        $v->validateName('a');
+    }
+
     public function testValidateEmail()
     {
         $v = new Validator();

--- a/tests/src/xAPI/Admin/ValidatorTest.php
+++ b/tests/src/xAPI/Admin/ValidatorTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace Tests\API;
+
+use Tests\TestCase;
+
+use API\Config;
+use API\Admin\Validator;
+use API\Admin\AdminException;
+
+class ValidatorTest extends TestCase
+{
+
+    public function testValidateEmail()
+    {
+        $v = new Validator();
+        $v->validateEmail('valid@email.com');
+
+        $this->expectException(AdminException::class);
+        $v->validateEmail('invalid');
+        $v->validateEmail(' valid@email.com'); // empty space
+        $v->validateEmail('invalid@');
+    }
+
+    public function testvalidatePassword()
+    {
+        $v = new Validator();
+        $v->validatePassword('ValidPass999!');
+
+        $this->expectException(AdminException::class);
+        $v->validatePassword('Val'); // too short
+        $v->validatePassword('ValidPass!'); // requires number
+        $v->validatePassword('ValidPass999'); // requires non alphaNumeric
+    }
+
+    public function validateXapiPermissions()
+    {
+        $available = Config::get(['xAPI', 'supported_auth_scopes'], []);
+
+        $v = new Validator();
+        $v->validateXapiPermissions(['all'], $available);
+        $v->validateXapiPermissions(['all', 'statements/read'], $available);
+
+        $this->expectException(AdminException::class);
+        $v->validateXapiPermissions('not an array', $available);
+        $v->validateXapiPermissions([], $available);
+        $v->validateXapiPermissions(['invalid'], $available);
+        $v->validateXapiPermissions(['invalid', 'statements/read'], $available);
+    }
+
+}

--- a/tests/src/xAPI/BootstrapTest.php
+++ b/tests/src/xAPI/BootstrapTest.php
@@ -227,5 +227,4 @@ class BootstrapTest extends TestCase
         $this->expectException(AppInitException::class);
         Config::all();
     }
-
 }


### PR DESCRIPTION
* Admin validator class
* storage and services, name based authScopes queries ( ['read','all'] => return records)
* storage, wrappers for mongo.distinct, mongo.executeCommand
* user collection, service, command add nerw fields name, description, createdAt to user record
* Brightcookie/lxHive-Internal#121 rules and validation for email, password, scopes

example user record:
```
{
    "_id" : ObjectId("593a0bb8a097fa1d4d71ece2"),
    "name" : "dgfds@dsfd",
    "description" : "fdgf",
    "email" : "jdjdj@gfd.de",
    "passwordHash" : "38f9a14c0f73c818a9c7ddf151dde6b11425f93a",
    "permissionIds" : [ 
        ObjectId("592f89d3a097fa4017306364"), 
        ObjectId("592f89d3a097fa4017306365")
    ],
    "createdAt" : ISODate("2017-06-09T02:45:13.001Z")
}
```