### PR TITLE
Issue #147 rfc2616 variants for authorization headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ src/xAPI/Config/Config.yml
 sftp-config.json
 
 .DS_Store
+
+.php_cs.cache

--- a/src/xAPI/Console/BasicTokenCreateCommand.php
+++ b/src/xAPI/Console/BasicTokenCreateCommand.php
@@ -59,7 +59,6 @@ class BasicTokenCreateCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-
         $basicAuthService = new BasicAuthService($this->getSlim());
         $scopesService =  new AuthScopesService($this->getSlim());
 
@@ -167,14 +166,14 @@ class BasicTokenCreateCommand extends Command
         }
 
         // permissions
-        $map = array_map(function($val) {
+        $map = array_map(function ($val) {
             return $val->getName();
         }, $user->permissions);
         $_scopes = array_values($map);
         $scopes = $_scopes;
 
         // Brightcookie/lxHive-Internal#125 fetch and merge child permissions for displaying options
-        foreach($_scopes as $scope) {
+        foreach ($_scopes as $scope) {
             $scopes += $scopesService->getChildrenFor($scope);
         }
         $scopesDictionary = $scopesService->findByNames($scopes, true);

--- a/src/xAPI/Console/BasicTokenCreateCommand.php
+++ b/src/xAPI/Console/BasicTokenCreateCommand.php
@@ -34,6 +34,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use API\Service\Auth\Basic as BasicAuthService;
 use API\Service\User as UserService;
+use API\Service\AuthScopes as AuthScopesService;
 
 class BasicTokenCreateCommand extends Command
 {
@@ -58,11 +59,14 @@ class BasicTokenCreateCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+
         $basicAuthService = new BasicAuthService($this->getSlim());
+        $scopesService =  new AuthScopesService($this->getSlim());
+
         $userService = new UserService($this->getSlim());
         $userService->fetchAll();
-        $users = [];
 
+        $users = [];
         foreach ($userService->getCursor() as $user) {
             $users[$user->get('email')] = $user;
         }
@@ -80,20 +84,20 @@ class BasicTokenCreateCommand extends Command
         ]);
 
         // get permissions from user service. Abort if no permissions set
-        $userService->fetchAvailablePermissions();
-        $hasPermissions = $userService->getCursor()->count();
-        if (!$hasPermissions) {
+        if (!$scopesService->count()) {
             throw new \RuntimeException(
                 'No oAuth scopes found. Please run command <comment>setup:oauth</comment> first'
             );
         }
 
+        // intro
         $question = new ConfirmationQuestion('Continue? (y/n) ', false);
         if (!$helper->ask($input, $output, $question)) {
             $output->writeln('<error>Process aborted by user.</error>');
             return 0;
         }
 
+        // email
         if (null === $input->getOption('email')) {
             $question = new Question('Please enter the email of the associated user: ', '');
             $question->setAutocompleterValues(array_keys($users));
@@ -138,7 +142,7 @@ class BasicTokenCreateCommand extends Command
             $user = $users[$email];
         }
 
-
+        // name
         if (null === $input->getOption('name')) {
             $question = new Question('Please enter a name: ', 'untitled');
             $name = $helper->ask($input, $output, $question);
@@ -146,6 +150,7 @@ class BasicTokenCreateCommand extends Command
             $name = $input->getOption('name');
         }
 
+        // description
         if (null === $input->getOption('description')) {
             $question = new Question('Please enter a description: ', '');
             $description = $helper->ask($input, $output, $question);
@@ -153,6 +158,7 @@ class BasicTokenCreateCommand extends Command
             $description = $input->getOption('description');
         }
 
+        // expiration
         if (null === $input->getOption('expiration')) {
             $question = new Question('Please enter the expiration timestamp for the token (blank == indefinite): ');
             $expiresAt = $helper->ask($input, $output, $question);
@@ -160,10 +166,18 @@ class BasicTokenCreateCommand extends Command
             $expiresAt = $input->getOption('expiration');
         }
 
-        $scopesDictionary = [];
-        foreach ($user->permissions as $scope) {
-            $scopesDictionary[$scope->getName()] = $scope;
+        // permissions
+        $map = array_map(function($val) {
+            return $val->getName();
+        }, $user->permissions);
+        $_scopes = array_values($map);
+        $scopes = $_scopes;
+
+        // Brightcookie/lxHive-Internal#125 fetch and merge child permissions for displaying options
+        foreach($_scopes as $scope) {
+            $scopes += $scopesService->getChildrenFor($scope);
         }
+        $scopesDictionary = $scopesService->findByNames($scopes, true);
 
         if (null === $input->getOption('scopes')) {
             $question = new ChoiceQuestion(
@@ -172,7 +186,6 @@ class BasicTokenCreateCommand extends Command
                 '0'
             );
             $question->setMultiselect(true);
-
             $selectedScopeNames = $helper->ask($input, $output, $question);
 
             $selectedScopes = [];

--- a/src/xAPI/Resource.php
+++ b/src/xAPI/Resource.php
@@ -212,6 +212,42 @@ abstract class Resource
     }
 
     /**
+     * Tries to fetch a \Slim\Http\Request header in variants "Propercase", "lowercase" and UPPERCASE".
+     *
+     * @param \Slim\Http\Request $request collection to search
+     * @param string $search
+     *
+     * @return mixed|false value or false if not found
+     */
+    public static function searchRequestHeaders($request, $search)
+    {
+        // \Slim\Http\Request::headers
+        $return = $request->headers()->get($search, false);
+        if(!$return){
+            $return = $request->headers()->get(strtolower($search), false);
+        }
+        if(!$return){
+            $return = $request->headers()->get(strtoupper($search), false);
+        }
+        if(!$return){
+            $return = $request->headers()->get(ucfirst($search), false);
+        }
+
+        // \Slim\Http\Request::rawHeaders
+        if(!$return){
+            $return = $request->rawHeaders()->get(strtolower($search), false);
+        }
+        if(!$return){
+            $return = $request->rawHeaders()->get(strtoupper($search), false);
+        }
+        if(!$return){
+            $return = $request->rawHeaders()->get(ucfirst($search), false);
+        }
+
+        return $return;
+    }
+
+    /**
      * @return \Slim\Slim
      */
     public function getSlim()

--- a/src/xAPI/Service/Auth/Basic.php
+++ b/src/xAPI/Service/Auth/Basic.php
@@ -330,10 +330,14 @@ class Basic extends Service implements AuthInterface
         }
 
         if (preg_match('/Basic\s+(.*)$/i', $header, $matches)) {
-            list($authUser, $authPass) = explode(':', base64_decode($matches[1]));
+            $str =  base64_decode($matches[1]);
         } else {
             throw new Exception('Authorization header invalid.');
         }
+
+        $components = explode(':', $str);
+        $authUser = $components[0];
+        $authPass = (isset($components[1])) ? $components[1] : '';
 
         if (isset($authUser) && isset($authPass)) {
             try {

--- a/src/xAPI/Service/Auth/Basic.php
+++ b/src/xAPI/Service/Auth/Basic.php
@@ -339,12 +339,10 @@ class Basic extends Service implements AuthInterface
         $authUser = $components[0];
         $authPass = (isset($components[1])) ? $components[1] : '';
 
-        if (isset($authUser) && isset($authPass)) {
-            try {
-                $token = $this->fetchToken($authUser, $authPass);
-            } catch (\Exception $e) {
-                throw new Exception('Authorization header invalid.');
-            }
+        try {
+            $token = $this->fetchToken($authUser, $authPass);
+        } catch (\Exception $e) {
+            throw new Exception('Authorization header invalid.');
         }
 
         return $token;

--- a/src/xAPI/Service/Auth/Basic.php
+++ b/src/xAPI/Service/Auth/Basic.php
@@ -319,13 +319,9 @@ class Basic extends Service implements AuthInterface
 
     public function extractToken(Request $request)
     {
-        $headers = $request->headers();
-        $rawHeaders = $request->rawHeaders();
-        if (isset($rawHeaders['Authorization'])) {
-            $header = $rawHeaders['Authorization'];
-        } elseif (isset($headers['Authorization'])) {
-            $header = $headers['Authorization'];
-        } else {
+        $header = Resource::searchRequestHeaders($request, 'Authorization');
+
+        if(false === $header){
             throw new Exception('Authorization header required.');
         }
 

--- a/src/xAPI/Service/Auth/OAuth.php
+++ b/src/xAPI/Service/Auth/OAuth.php
@@ -388,16 +388,16 @@ class OAuth extends Service implements AuthInterface
 
     public function extractToken(Request $request)
     {
-        $tokenHeader = $request->headers('Authorization', false);
-        $rawTokenHeader = $request->rawHeaders('Authorization', false);
+        $tokenHeader = Resource::searchRequestHeaders($request, 'Authorization');
 
-        if ($tokenHeader && preg_match('/Bearer\s*([^\s]+)/', $tokenHeader, $matches)) {
-            $tokenHeader = $matches[1];
-        } elseif ($rawTokenHeader && preg_match('/Bearer\s*([^\s]+)/', $rawTokenHeader, $matches)) {
-            $tokenHeader = $matches[1];
-        } else {
-            $tokenHeader = false;
+        if(false === $tokenHeader){
+            throw new Exception('The request is missing a required parameter.', Resource::STATUS_BAD_REQUEST);
         }
+
+        if (preg_match('/Bearer\s*([^\s]+)/', $tokenHeader, $matches)) {
+            $tokenHeader = $matches[1];
+        }
+
         $tokenRequest = $request->post('access_token', false);
         $tokenQuery = $request->get('access_token', false);
         // At least one (and only one) of client credentials method required.

--- a/src/xAPI/Service/AuthScopes.php
+++ b/src/xAPI/Service/AuthScopes.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of lxHive LRS - http://lxhive.org/
+ *
+ * Copyright (C) 2015 Brightcookie Pty Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lxHive. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For authorship information, please view the AUTHORS
+ * file that was distributed with this source code.
+ */
+
+namespace API\Service;
+
+use API\Service;
+use API\Resource;
+
+class AuthScopes extends Service
+{
+
+    /**
+     * counts permission doocuments
+     * @return int
+     */
+    public function count()
+    {
+        $collection = $this->getDocumentManager()->getCollection('authScopes');
+        $cursor     = $collection->find();
+        return $cursor->count();
+    }
+
+    /**
+     * Gets all permission documents
+     * @param bool $dictionary return as associative array of documents (permission name)
+     * @return array of \Sokil\Mongo\Document
+     */
+    public function fetchAll($dictionary = false)
+    {
+        $collection = $this->getDocumentManager()->getCollection('authScopes');
+        $cursor     = $collection->find();
+        $documents  = $cursor->findAll();
+
+        if (!$dictionary) {
+            return $documents;
+        }
+
+        $dictionary = [];
+        foreach ($cursor as $permission) {
+            $dictionary[$permission->getName()] = $permission;
+        }
+        return $dictionary;
+    }
+
+    /**
+     * Gets a single registered permission document by id
+     * @param string $id
+     * @return \Sokil\Mongo\Document|null
+     */
+    public function findById($id)
+    {
+        $collection = $this->getDocumentManager()->getCollection('authScopes');
+        return $collection->getDocument($id);
+    }
+
+    /**
+     * Gets a single registered permission document by name
+     * @param string $name
+     * @return \Sokil\Mongo\Document|null
+     */
+    public function findByName($name)
+    {
+        $collection = $this->getDocumentManager()->getCollection('authScopes');
+        $cursor     = $collection->find();
+        $cursor->where('name', $name);
+        $scopeDocument = $cursor->current();
+        return $scopeDocument;
+    }
+
+}

--- a/src/xAPI/Service/AuthScopes.php
+++ b/src/xAPI/Service/AuthScopes.php
@@ -29,7 +29,6 @@ use API\Resource;
 
 class AuthScopes extends Service
 {
-
     private $matrix = [
         'super' => [
             'all'
@@ -71,12 +70,12 @@ class AuthScopes extends Service
      */
     public function getChildrenFor($name)
     {
-        if(!isset($this->matrix[$name])) {
+        if (!isset($this->matrix[$name])) {
             return [];
         }
 
         $children = $this->matrix[$name];
-        foreach($children as $c){
+        foreach ($children as $c) {
             if (in_array($name, $children)) {
                 continue;
             }
@@ -172,5 +171,4 @@ class AuthScopes extends Service
 
         return ($dictionary) ? $dictionary : array_values($dictionary);
     }
-
 }

--- a/src/xAPI/Service/User.php
+++ b/src/xAPI/Service/User.php
@@ -131,7 +131,7 @@ class User extends Service
     {
         $rememberMeStorage = new RemembermeMongoStorage($this->getDocumentManager());
         $rememberMe = new Rememberme\Authenticator($rememberMeStorage);
-        
+
         if (isset($_SESSION['userId']) && isset($_SESSION['expiresAt']) && $_SESSION['expiresAt'] > time()) {
             $_SESSION['expiresAt'] = time() + 3600; //Renew session on every activity
             return true;
@@ -226,12 +226,8 @@ class User extends Service
 
     public function fetchAvailablePermissions()
     {
-        $collection  = $this->getDocumentManager()->getCollection('authScopes');
-        $cursor      = $collection->find();
-
-        $this->cursor = $cursor;
-
-        return $this;
+        $service = new AuthScopes($this->getSlim());
+        return $service->fetchAll();
     }
 
     /**

--- a/src/xAPI/Service/User.php
+++ b/src/xAPI/Service/User.php
@@ -135,7 +135,7 @@ class User extends Service
         if (isset($_SESSION['userId']) && isset($_SESSION['expiresAt']) && $_SESSION['expiresAt'] > time()) {
             $_SESSION['expiresAt'] = time() + 3600; //Renew session on every activity
             return true;
-        } else if (!empty($_COOKIE[$rememberMe->getCookieName()]) && $rememberMe->cookieIsValid()) { // Remember me cookie
+        } elseif (!empty($_COOKIE[$rememberMe->getCookieName()]) && $rememberMe->cookieIsValid()) { // Remember me cookie
             $loginresult = $rememberMe->login();
             if ($loginresult) {
                 // Load user into session and return true


### PR DESCRIPTION
commit: https://github.com/Brightcookie/lxHive/commit/88c854c0a288ad92b02d0d0084a07b537dcdaae5

@sraka1 Please check. did manual testing,  The issue solves this only for basic and oAuth, but provides a convenience method `Resource::searchRequestHeaders` for other cases.

This needs also to be checked and implemented in development. Give us an estimate please

(includes changes from PR https://github.com/Brightcookie/lxHive/pull/145)