### PR TITLE
Add extension info to /about endpoint

### DIFF
--- a/src/xAPI/Extensions/ExtendedQuery/ExtendedQuery.php
+++ b/src/xAPI/Extensions/ExtendedQuery/ExtendedQuery.php
@@ -35,17 +35,9 @@ class ExtendedQuery implements ExtensionInterface
 {
     use BaseTrait;
 
-    //private $routes = [
-    //    '/plus/statements/find' => [
-    //        'methods' => [
-    //            'OPTIONS'   => [ 'callable' => 'handleOptionsRoute'],
-    //            'GET'       => [ 'callable' => 'handleGetRoute'],
-    //            'HEAD'      => [ 'callable' => 'handleGetRoute'],
-    //            'POST'      => [ 'callable' => 'handlePostRoute'],
-    //        ],
-    //    ],
-    //];
-
+    /**
+     * @var array $routes
+     */
     private $routes = [
         ['pattern' => '/plus/statements/find', 'callable' => 'handleGetRoute', 'methods' => ['GET', 'HEAD']],
         ['pattern' => '/plus/statements/find', 'callable' => 'handlePostRoute', 'methods' => ['POST']],

--- a/src/xAPI/Extensions/ExtendedQuery/ExtendedQuery.php
+++ b/src/xAPI/Extensions/ExtendedQuery/ExtendedQuery.php
@@ -71,7 +71,7 @@ class ExtendedQuery implements ExtensionInterface
         $routes = [];
         foreach ($this->routes as $route) {
             $pattern = $route['pattern'];
-            $methods = (isset($routes[$pattern])) ? array_merge($routes[$pattern], $route['methods']) : [];
+            $methods = (isset($routes[$pattern])) ? array_merge($routes[$pattern], $route['methods']) : $route['methods'];
             $routes[$pattern] = $methods;
         }
 

--- a/src/xAPI/Extensions/ExtendedQuery/ExtendedQuery.php
+++ b/src/xAPI/Extensions/ExtendedQuery/ExtendedQuery.php
@@ -35,6 +35,23 @@ class ExtendedQuery implements ExtensionInterface
 {
     use BaseTrait;
 
+    //private $routes = [
+    //    '/plus/statements/find' => [
+    //        'methods' => [
+    //            'OPTIONS'   => [ 'callable' => 'handleOptionsRoute'],
+    //            'GET'       => [ 'callable' => 'handleGetRoute'],
+    //            'HEAD'      => [ 'callable' => 'handleGetRoute'],
+    //            'POST'      => [ 'callable' => 'handlePostRoute'],
+    //        ],
+    //    ],
+    //];
+
+    private $routes = [
+        ['pattern' => '/plus/statements/find', 'callable' => 'handleGetRoute', 'methods' => ['GET', 'HEAD']],
+        ['pattern' => '/plus/statements/find', 'callable' => 'handlePostRoute', 'methods' => ['POST']],
+        ['pattern' => '/plus/statements/find', 'callable' => 'handleOptionsRoute', 'methods' => ['OPTIONS']],
+    ];
+
     /**
      * constructor
      * Register services
@@ -43,6 +60,33 @@ class ExtendedQuery implements ExtensionInterface
     public function __construct($container)
     {
         $this->setContainer($container);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function about()
+    {
+
+        $routes = [];
+        foreach ($this->routes as $route) {
+            $pattern = $route['pattern'];
+            $methods = (isset($routes[$pattern])) ? array_merge($routes[$pattern], $route['methods']) : [];
+            $routes[$pattern] = $methods;
+        }
+
+        return [
+            'name' => 'ExtendedQuery',
+            'description' => 'Fragmented statement queries',
+            'endpoints' => $routes,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function install()
+    {
     }
 
     /**
@@ -60,11 +104,7 @@ class ExtendedQuery implements ExtensionInterface
      */
     public function getRoutes()
     {
-        return [
-            ['pattern' => '/plus/statements/find', 'callable' => 'handleGetRoute', 'methods' => ['GET', 'HEAD']],
-            ['pattern' => '/plus/statements/find', 'callable' => 'handlePostRoute', 'methods' => ['POST']],
-            ['pattern' => '/plus/statements/find', 'callable' => 'handleOptionsRoute', 'methods' => ['OPTIONS']],
-        ];
+        return $this->routes;
     }
 
     /**
@@ -74,14 +114,6 @@ class ExtendedQuery implements ExtensionInterface
     public function getHooks()
     {
         return [];
-    }
-
-    /**
-     * Called by extension initializer, does nothing.
-     * @return void
-     */
-    public function install()
-    {
     }
 
     /**

--- a/src/xAPI/Extensions/ExtensionInterface.php
+++ b/src/xAPI/Extensions/ExtensionInterface.php
@@ -47,4 +47,11 @@ interface ExtensionInterface
      * @return void
     */
     public function install();
+
+    /**
+     * Provide information for /about endpoint
+     * @see https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Communication.md#aboutresource
+     * @return array
+    */
+    public function about();
 }

--- a/src/xAPI/View/V10/About.php
+++ b/src/xAPI/View/V10/About.php
@@ -32,7 +32,10 @@ class About extends View
 {
     public function render()
     {
-        $object = ['version' => $this->versions];
+        $object = [
+            'version' => $this->versions,
+            'extensions' => $this->extensions
+        ];
 
         return $object;
     }


### PR DESCRIPTION

```
{"version":["1.0.2"],"extensions":[{"name":"ExtendedQuery","description":"Fragmented statement queries","endpoints":{"\/plus\/statements\/find":["GET","HEAD","POST","OPTIONS"]}}]}
```

ExtensionInterface 

* requires now an `about()` method implementation

ExtendedQuery:

* separated routes into private class var

AboutView

 * added extension info aggregation