### PR TITLE
Routes API

### DIFF
--- a/src/xAPI/Bootstrap.php
+++ b/src/xAPI/Bootstrap.php
@@ -567,8 +567,8 @@ class Bootstrap
                     }
 
                     // Load any routes added by extension
-                    $_routes = $extension->getRoutes();
-                    $router->merge($_routes);
+                    $extensionRoutes = $extension->getRoutes();
+                    $router->merge($extensionRoutes);
                 }
             }
         }
@@ -586,8 +586,6 @@ class Bootstrap
             });
 
         }
-
-
 
         return $app;
     }

--- a/src/xAPI/Bootstrap.php
+++ b/src/xAPI/Bootstrap.php
@@ -539,6 +539,16 @@ class Bootstrap
             return $response;
         });
 
+        ////
+        // ROUTER
+        ////
+
+        $router = new Routes();
+        $routes = $router->all();
+
+        ////
+        // Extensions
+        ////
 
         // Load extensions (event listeners and routes) that may exist
         $extensions = Config::get('extensions');
@@ -548,7 +558,6 @@ class Bootstrap
                 if ($extension['enabled'] === true) {
                     // Instantiate the extension class
                     $className = $extension['class_name'];
-
                     $extension = new $className($container);
 
                     // Load any xAPI event handlers added by the extension
@@ -558,21 +567,15 @@ class Bootstrap
                     }
 
                     // Load any routes added by extension
-                    $routes = $extension->getRoutes();
-                    foreach ($routes as $route) {
-                        $app->map($route['methods'], $route['pattern'], [$extension, $route['callable']]);
-                    }
+                    $_routes = $extension->getRoutes();
+                    $router->merge($_routes);
                 }
             }
         }
 
         ////
-        // ROUTING
-        // TODO: Move this chunk of code to a separate class like API\Router in future
+        // SlimApp
         ////
-
-        $routes = new Routes();
-        $routes = $routes->all();
 
         foreach ($routes as $pattern => $route){
             // register single route with methods and controller
@@ -583,6 +586,8 @@ class Bootstrap
             });
 
         }
+
+
 
         return $app;
     }

--- a/src/xAPI/Bootstrap.php
+++ b/src/xAPI/Bootstrap.php
@@ -571,96 +571,18 @@ class Bootstrap
         // TODO: Move this chunk of code to a separate class like API\Router in future
         ////
 
-        // About
-        $app->map(['GET', 'OPTIONS'], '/about', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'about');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
+        $routes = new Routes();
+        $routes = $routes->all();
 
-        // Activities
-        $app->map(['GET', 'OPTIONS'], '/activities', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'activities');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
+        foreach ($routes as $pattern => $route){
+            // register single route with methods and controller
+            $app->map($route['methods'], $pattern, function ($request, $response, $args) use ($container, $route) {
+                $resource = Controller::load($container, $request, $response, $route['controller']);
+                $method = strtolower($request->getMethod());
+                return $resource->$method();
+            });
 
-        // ActivitiesProfile
-        $app->map(['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'], '/activities/profile', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'activities', 'profile');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
-
-        // ActivitiesState
-        $app->map(['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'], '/activities/state', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'activities', 'state');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
-
-        // Agents
-        $app->map(['GET', 'OPTIONS'], '/agents', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'agents');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
-
-        // AgentsProfile
-        $app->map(['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'], '/agents/profile', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'agents', 'profile');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
-
-        // AgentsState
-        $app->map(['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'], '/agents/state', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'agents', 'state');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
-
-        // Attachments
-        $app->map(['GET', 'OPTIONS'], '/attachments', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'attachments');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
-
-        // AuthTokens
-        $app->map(['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'], '/auth/tokens', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'auth', 'tokens');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
-
-        // OAuthAuthorize
-        $app->map(['GET', 'POST', 'OPTIONS'], '/oauth/authorize', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'oauth', 'authorize');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
-
-        // OAuthLogin
-        $app->map(['GET', 'POST', 'OPTIONS'], '/oauth/login', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'oauth', 'login');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
-
-        // OAuthToken
-        $app->map(['POST', 'OPTIONS'], '/oauth/token', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'oauth', 'token');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
-
-        // Statements
-        $app->map(['GET', 'PUT', 'POST', 'OPTIONS'], '/statements', function ($request, $response, $args) use ($container) {
-            $resource = Controller::load($container['version'], $container, $request, $response, 'statements');
-            $method = strtolower($request->getMethod());
-            return $resource->$method();
-        });
+        }
 
         return $app;
     }

--- a/src/xAPI/Controller.php
+++ b/src/xAPI/Controller.php
@@ -212,23 +212,16 @@ abstract class Controller
      *
      * @return \API\ControllerInterface
      */
-    public static function load($version, $container, $request, $response, $resource, $subResource = null)
+    public static function load($container, $request, $response, $controllerClass)
     {
-        $versionNamespace = $version->generateClassNamespace();
-        if (null !== $subResource) {
-            $class = __NAMESPACE__.'\\Controller\\'.$versionNamespace.'\\'.ucfirst($resource).'\\'.ucfirst($subResource);
-        } else {
-            $class = __NAMESPACE__.'\\Controller\\'.$versionNamespace.'\\'.ucfirst($resource);
-        }
-
-        if (!class_exists($class)) {
+        if (!class_exists($controllerClass)) {
             $errorResource = new Error($container, $request, $response);
             $errorResource = $errorResource->error(self::STATUS_NOT_FOUND, 'Cannot find requested resource.');
 
             return $errorResource;
         }
 
-        return new $class($container, $request, $response);
+        return new $controllerClass($container, $request, $response);
     }
 
     /**

--- a/src/xAPI/Routes.php
+++ b/src/xAPI/Routes.php
@@ -1,0 +1,149 @@
+<?php
+/*
+ * This file is part of lxHive LRS - http://lxhive.org/
+ *
+ * Copyright (C) 2017 Brightcookie Pty Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lxHive. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For authorship information, please view the AUTHORS
+ * file that was distributed with this source code.
+ *
+ * This file was adapted from slim.
+ * License information is available at https://github.com/slimphp/Slim/blob/3.x/LICENSE.md
+ *
+ */
+
+namespace API;
+
+class Routes
+{
+
+    /**
+     * @var array $routes default routes
+     *
+     * pattern:
+     * [
+     *    (string) "module":      core app module (or "extension"),
+     *    (array)  "methods":     array of HTTP methods for this route
+     *    (string) "description": a short description for the LRS /about view
+     *    (string) "controller:   fully namespaced controller class name,
+     *  ]
+     */
+    private static $routes = [
+
+        // xAPI routes
+
+        '/about' => [
+            'module' => 'xAPI',
+            'methods' => ['GET', 'OPTIONS'],
+            'description' =>'LRS Information',
+            'controller' => 'API\\Controller\\V10\\About',
+        ],
+        '/activities' => [
+            'module' => 'xAPI',
+            'methods' => ['GET', 'OPTIONS'],
+            'description' =>'Activity Object Storage/Retrieval',
+            'controller' => 'API\\Controller\\V10\\Activities',
+        ],
+        '/activities/profile' => [
+            'module' => 'xAPI',
+            'methods' => ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
+            'description' =>'Activity Profile Resource',
+            'controller' => 'API\\Controller\\V10\\Activities\\Profile',
+        ],
+        '/activities/state' => [
+            'module' => 'xAPI',
+            'methods' => ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
+            'description' =>'State Resource',
+            'controller' => 'API\\Controller\\V10\\Activities\\State',
+        ],
+        '/agents' => [
+            'module' => 'xAPI',
+            'methods' => ['GET', 'OPTIONS'],
+            'description' =>'Agent Object Storage/Retrieval',
+            'controller' => 'API\\Controller\\V10\\Agents',
+        ],
+        '/agents/profile' => [
+            'module' => 'xAPI',
+            'methods' => ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
+            'description' =>'Agent Profile Resource',
+            'controller' => 'API\\Controller\\V10\\Profile',
+        ],
+        'pattern: /statements' => [
+            'module' => 'xAPI',
+            'methods' => ['GET', 'PUT', 'POST', 'OPTIONS'],
+            'description' =>'Statement Storage/Retrieval',
+            'controller' => 'API\\Controller\\V10\\Statements',
+        ],
+
+        // oAuth routes
+
+        '/oauth/authorize' => [
+            'module' => 'oAuth',
+            'methods' => ['GET', 'POST', 'OPTIONS'],
+            'description' =>'Resource Owner Authorization',
+            'controller' => 'API\\Controller\\V10\\Oauth\\Authorize',
+        ],
+        '/oauth/login' => [
+            'module' => 'oAuth',
+            'methods' => ['GET', 'POST', 'OPTIONS'],
+            'description' =>'Resource Owner Login',
+            'controller' => 'API\\Controller\\V10\\Oauth\\Login',
+        ],
+        'pattern: /oauth/token' => [
+            'module' => 'oAuth',
+            'methods' => ['POST', 'OPTIONS'],
+            'description' =>'Token Request',
+            'controller' => 'API\\Controller\\V10\\Oauth\\Token',
+        ],
+
+        // custom
+
+        '/attachments' => [
+            'module' => 'Storage',
+            'methods' => ['GET', 'OPTIONS'],
+            'description' =>'Attachment file retrieval',
+            'controller' => 'API\\Controller\\V10\\Attachments',
+        ],
+
+        '/auth/tokens' => [
+            'module' => 'Auth',
+            'methods' => ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
+            'description' =>'Temporary BASIC token endpoint',
+            'controller' => 'API\\Controller\\V10\\Auth\\Tokens',
+        ],
+    ];
+
+    /**
+     * Returns all routes
+     *
+     * @return array self::$routes
+     */
+    public function all()
+    {
+        return self::$routes;
+    }
+
+    /**
+     * Merges an array of new routes into self::$routes.
+     * The merging order ensures that extising routes are not overwritten by new routes
+     *
+     * @return void
+     */
+    public function merge(array $routes)
+    {
+        self::$routes = array_merge($routes, self::$routes);
+    }
+}


### PR DESCRIPTION
**Proposal**, don't merge automatically!

Simple router API

**src/xAPI/Bootstrap.php**

* removed routes, they are now loaded from API/Routes and handed over to the Controller via a simple loop

**src/xAPI/Controller.php**

* simplified loader, removed name space compiling logic (performance)

**src/xAPI/Routes.php**

* provides and stores routes data.

**TODO**

Apply to extension API
* unit tests