### PR TITLE
prepare version awareness between application and configuration

### DIFF
--- a/src/xAPI/Bootstrap.php
+++ b/src/xAPI/Bootstrap.php
@@ -55,7 +55,12 @@ use API\Console\Application as CliApp;
 class Bootstrap
 {
     /**
-     * @vars Bootstrap Mode
+     * @var string VERSION phpversion() parable application version  string(SemVer), synchs with Config.yml version
+     */
+    const VERSION = '0.9.5';
+
+    /**
+     * @var Bootstrap Mode
      */
     const None    = 0;
     const Web     = 1;
@@ -217,7 +222,6 @@ class Bootstrap
         Config::factory($defaults);
 
         $filesystem = new \League\Flysystem\Filesystem(new \League\Flysystem\Adapter\Local($appRoot));
-
         $yamlParser = new YamlParser();
 
         try {

--- a/src/xAPI/Config/Templates/Config.yml
+++ b/src/xAPI/Config/Templates/Config.yml
@@ -1,5 +1,6 @@
 name: lxHive
 mode: production
+version: 0.9.5
 storage:
     in_use: Mongo
     Mongo:


### PR DESCRIPTION
Brightcookie/lxHive-Internal#132

Either Config.yml (template) and Bootstrap contain a SemVer version string. This will help future migration scripts to deal with upgrades.

At the moment there is no logic yet attached, but for the new release we should think about exiting on bootstrap level if no version property is found in the config (which would mean it's an invalid 0.9.1 config)