### PR TITLE
DocumentResult -> shortcut for getting PHP values from cursor

### DIFF
--- a/src/xAPI/Bootstrap.php
+++ b/src/xAPI/Bootstrap.php
@@ -55,7 +55,12 @@ use API\Console\Application as CliApp;
 class Bootstrap
 {
     /**
-     * @vars Bootstrap Mode
+     * @var string VERSION phpversion() parable application version  string(SemVer), synchs with Config.yml version
+     */
+    const VERSION = '0.9.5';
+
+    /**
+     * @var Bootstrap Mode
      */
     const None    = 0;
     const Web     = 1;
@@ -217,7 +222,6 @@ class Bootstrap
         Config::factory($defaults);
 
         $filesystem = new \League\Flysystem\Filesystem(new \League\Flysystem\Adapter\Local($appRoot));
-
         $yamlParser = new YamlParser();
 
         try {

--- a/src/xAPI/Config/Templates/Config.yml
+++ b/src/xAPI/Config/Templates/Config.yml
@@ -1,5 +1,6 @@
 name: lxHive
 mode: production
+version: 0.9.5
 storage:
     in_use: Mongo
     Mongo:

--- a/src/xAPI/Storage/Query/DocumentResult.php
+++ b/src/xAPI/Storage/Query/DocumentResult.php
@@ -213,4 +213,15 @@ class DocumentResult
 
         return $this;
     }
+
+    /**
+     * Exports the cursor values as neares PHP data type
+     *
+     * @return object|array returns by default a stdClass if no other typeMap was set for cursor
+     */
+    public function toValues()
+    {
+        return $this->cursor->toArray();
+    }
+
 }


### PR DESCRIPTION
DocumentResult::getValues shortcut for dummies

```php
        $model = $this->getStorage()->getAuthScopesStorage()->fetchAll();
        $records = $model->toValues();
```