### PR TITLE
smaller fixes, validator debug mode

### DIFF
--- a/src/xAPI/Admin/Auth.php
+++ b/src/xAPI/Admin/Auth.php
@@ -147,7 +147,7 @@ class Auth extends Admin
      *
      * @return \API\Document\AccessToken
      */
-    public function addToken($name, $description, $expiresAt, $user, $selectedScopes, $key, $secret)
+    public function addToken($name, $description, $expiresAt, $user, $selectedScopes, $key = null, $secret = null)
     {
         $basicAuthService = new BasicAuthService($this->getContainer());
         $token = $basicAuthService->addToken($name, $description, $expiresAt, $user, $selectedScopes, $key, $secret);

--- a/src/xAPI/Service/Auth.php
+++ b/src/xAPI/Service/Auth.php
@@ -142,7 +142,8 @@ class Auth extends Service
         if(empty($this->scopes[$name]['inherits'])){
             return [];
         }
-        return $this->scopes[$name]['inherits'];
+        // yaml parses empty arrays to {}
+        return (array) $this->scopes[$name]['inherits'];
     }
 
     /**

--- a/tests/src/xAPI/Storage/Adapter/Mongo/BasicAuthTest.php
+++ b/tests/src/xAPI/Storage/Adapter/Mongo/BasicAuthTest.php
@@ -80,5 +80,10 @@ class BasicAuthTest extends MongoTestCase
         $this->assertEquals($t->expiresAt->toDateTime()->getTimestamp(), $mock->expiresAt);
         $this->assertEquals((string) $t->userId, (string) $mock->user->_id);
         $this->assertEquals($t->permissions, $mock->permissions);
+
+        $this->assertTrue(isset($t->key), 'a default key was created');
+        $this->assertTrue(isset($t->secret), 'a default secret was created');
+        $this->assertGreaterThan(3, strlen($t->key));
+        $this->assertGreaterThan(3, strlen($t->secret));
     }
 }


### PR DESCRIPTION
linked existing Jsonschema validator debug mode to Config, can now be triggered via `debug` parameter in Config.<state>.yml