### PR TITLE
version header fix

### DIFF
--- a/src/xAPI/Bootstrap.php
+++ b/src/xAPI/Bootstrap.php
@@ -458,19 +458,19 @@ class Bootstrap
 
             if (!$versionString) {
                 throw new HttpException('X-Experience-API-Version header missing.', Controller::STATUS_BAD_REQUEST);
-            } else {
-                try {
-                    $version = Versioning::fromString($versionString);
-                } catch (\InvalidArgumentException $e) {
-                    throw new HttpException('X-Experience-API-Version header invalid.', Controller::STATUS_BAD_REQUEST);
-                }
-
-                if (!in_array($versionString, Config::get(['xAPI', 'supported_versions']))) {
-                    throw new HttpException('X-Experience-API-Version is not supported.', Controller::STATUS_BAD_REQUEST);
-                }
-
-                return $version;
             }
+
+            try {
+                $version = Versioning::fromString($versionString);
+            } catch (\InvalidArgumentException $e) {
+                throw new HttpException('X-Experience-API-Version header invalid.', Controller::STATUS_BAD_REQUEST);
+            }
+
+            if (!in_array($versionString, Config::get(['xAPI', 'supported_versions']))) {
+                throw new HttpException('X-Experience-API-Version is not supported.', Controller::STATUS_BAD_REQUEST);
+            }
+
+            return $version;
         };
 
         return $container;

--- a/src/xAPI/Validator.php
+++ b/src/xAPI/Validator.php
@@ -111,9 +111,7 @@ abstract class Validator
     public function validateRequest()
     {
         $headers = $this->getContainer()->get('parser')->getData()->getHeaders();
-        if (empty($headers['x-experience-api-version'])) {
-            throw new Exception('X-Experience-API-Version header missing.', Controller::STATUS_BAD_REQUEST);
-        }
+        $version = $this->getContainer()->get('version'); //run version container
     }
 
     /**


### PR DESCRIPTION
https://github.com/Brightcookie/lxHive-Internal/issues/214, container callback not called

as long there are no unit tests... 

```
node ./test -g 'API Versioning @1.03, @1.0.2'
```

now passing