### PR TITLE
Extend justinrainbow/json-schema, a custom formats for IRI and UUID

### DIFF
--- a/src/xAPI/Bootstrap.php
+++ b/src/xAPI/Bootstrap.php
@@ -458,19 +458,19 @@ class Bootstrap
 
             if (!$versionString) {
                 throw new HttpException('X-Experience-API-Version header missing.', Controller::STATUS_BAD_REQUEST);
-            } else {
-                try {
-                    $version = Versioning::fromString($versionString);
-                } catch (\InvalidArgumentException $e) {
-                    throw new HttpException('X-Experience-API-Version header invalid.', Controller::STATUS_BAD_REQUEST);
-                }
-
-                if (!in_array($versionString, Config::get(['xAPI', 'supported_versions']))) {
-                    throw new HttpException('X-Experience-API-Version is not supported.', Controller::STATUS_BAD_REQUEST);
-                }
-
-                return $version;
             }
+
+            try {
+                $version = Versioning::fromString($versionString);
+            } catch (\InvalidArgumentException $e) {
+                throw new HttpException('X-Experience-API-Version header invalid.', Controller::STATUS_BAD_REQUEST);
+            }
+
+            if (!in_array($versionString, Config::get(['xAPI', 'supported_versions']))) {
+                throw new HttpException('X-Experience-API-Version is not supported.', Controller::STATUS_BAD_REQUEST);
+            }
+
+            return $version;
         };
 
         return $container;

--- a/src/xAPI/Util/xAPI.php
+++ b/src/xAPI/Util/xAPI.php
@@ -87,6 +87,6 @@ class xAPI
      */
     public static function sanitizeUuid($uuid)
     {
-        return strtolower(str_replace(array('urn:', 'uuid:', '{', '}'), '', $uuid));
+        return strtolower(str_replace(['urn:', 'uuid:', '{', '}'], '', $uuid));
     }
 }

--- a/src/xAPI/Util/xAPI.php
+++ b/src/xAPI/Util/xAPI.php
@@ -78,4 +78,15 @@ class xAPI
         //invalid or falsy objectType values
         return null;
     }
+
+    /**
+     * Sanitizes upercase and legacy UUID patterns (issue#76)
+     * @param string $uuid
+     *
+     * @return string sanitized uuid (ready for \Mongo\ObjectId::__constuct())
+     */
+    public static function sanitizeUuid($uuid)
+    {
+        return strtolower(str_replace(array('urn:', 'uuid:', '{', '}'), '', $uuid));
+    }
 }

--- a/src/xAPI/Validator.php
+++ b/src/xAPI/Validator.php
@@ -24,12 +24,16 @@
 
 namespace API;
 
-use API\Config;
-use JsonSchema;
-use API\HttpException as Exception;
 use API\BaseTrait;
+use API\Config;
 
-abstract class Validator
+use JsonSchema;
+use API\Validator\JsonSchema\Constraints\Factory as Factory;
+
+use API\HttpException as Exception;
+
+
+class Validator
 {
     use BaseTrait;
 
@@ -59,6 +63,17 @@ abstract class Validator
     }
 
     /**
+     * Create JsonSchema\Validator instance
+     * @param Factory $factory
+     *
+     * @return JsonSchema\Validator
+     */
+    public function createSchemaValidator($factory)
+    {
+        return new JsonSchema\Validator($factory);
+    }
+
+    /**
      * Validate data with JsonSchema
      * We intentionally create a new Validator instance on each call.
      *
@@ -70,7 +85,7 @@ abstract class Validator
     public function validateSchema($data, $uri)
     {
         $schema = self::$schemaStorage->getSchema($uri);
-        $validator = new JsonSchema\Validator(new JsonSchema\Constraints\Factory(self::$schemaStorage, null, JsonSchema\Constraints\Constraint::CHECK_MODE_TYPE_CAST));
+        $validator = new JsonSchema\Validator(new Factory(self::$schemaStorage, null, JsonSchema\Constraints\Constraint::CHECK_MODE_TYPE_CAST));
         $validator->check($data, $schema);
 
         if ($this->debug) {

--- a/src/xAPI/Validator.php
+++ b/src/xAPI/Validator.php
@@ -111,9 +111,7 @@ abstract class Validator
     public function validateRequest()
     {
         $headers = $this->getContainer()->get('parser')->getData()->getHeaders();
-        if (empty($headers['x-experience-api-version'])) {
-            throw new Exception('X-Experience-API-Version header missing.', Controller::STATUS_BAD_REQUEST);
-        }
+        $version = $this->getContainer()->get('version'); //run version container
     }
 
     /**

--- a/src/xAPI/Validator/JsonSchema/Constraints/Factory.php
+++ b/src/xAPI/Validator/JsonSchema/Constraints/Factory.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * This file is part of lxHive LRS - http://lxhive.org/
+ *
+ * Copyright (C) 2017 Brightcookie Pty Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lxHive. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For authorship information, please view the AUTHORS
+ * file that was distributed with this source code.
+ */
+
+
+namespace API\Validator\JsonSchema\Constraints;
+
+use JsonSchema;
+
+/**
+ * Factory for centralize constraint initialization.
+ */
+class Factory extends JsonSchema\Constraints\Factory
+{
+    /**
+     * @var array $customConstraintMap
+     */
+    protected $customConstraints = [
+        'format' => '\API\Validator\JsonSchema\Constraints\FormatConstraint',
+    ];
+
+    /**
+     *
+     * @param JsonSchema\SchemaStorageInterface $schemaStorage
+     * @param JsonSchema\UriRetrieverInterface $uriRetriever
+     * @param int $checkMode
+     *
+     * @see JsonSchema\Constraints\Factory
+     */
+    public function __construct(
+        JsonSchema\SchemaStorageInterface $schemaStorage = null,
+        JsonSchema\UriRetrieverInterface $uriRetriever = null,
+        $checkMode = JsonSchema\Constraints\Constraint::CHECK_MODE_NORMAL
+    ) {
+        // merge custom constraints
+        $this->constraintMap = array_merge($this->constraintMap, $this->customConstraints);
+        parent::__construct($schemaStorage, $uriRetriever, $checkMode);
+        //var_dump($this->constraintMap);
+
+    }
+
+    /**
+     * Gets merge class map of constraints (for tests)
+     *
+     * @return array $constraintMap
+     */
+    public function getConstraintMap()
+    {
+        return $this->constraintMap;
+    }
+}

--- a/src/xAPI/Validator/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/xAPI/Validator/JsonSchema/Constraints/FormatConstraint.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ * This file is part of lxHive LRS - http://lxhive.org/
+ *
+ * Copyright (C) 2017 Brightcookie Pty Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lxHive. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For authorship information, please view the AUTHORS
+ * file that was distributed with this source code.
+ */
+
+
+namespace API\Validator\JsonSchema\Constraints;
+
+use JsonSchema;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Validates against the 'format' property
+ */
+class FormatConstraint extends JsonSchema\Constraints\FormatConstraint
+{
+    /**
+     * Invokes the validation of an element
+     *
+     * @param mixed            $value
+     * @param mixed            $schema
+     * @param JsonPointer|null $path
+     * @param mixed            $i
+     * @throws \JsonSchema\Exception\ExceptionInterface
+     */
+    public function check($element, $schema = null, JsonSchema\Entity\JsonPointer $path = null, $i = null)
+    {
+
+        if (!isset($schema->format)) {
+            return;
+        }
+
+        switch ($schema->format) {
+            // @see https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
+            // @see https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier
+            // @see https://www.w3.org/TR/uri-clarification/
+            // @see http://tools.ietf.org/html/rfc3987
+            case 'iri':
+                if (null === filter_var($element, FILTER_VALIDATE_URL, FILTER_NULL_ON_FAILURE)) {
+                    $parsed = parse_url($element);
+                    // PHP FILTER_VALIDATE_URL covers only rfc2396, non-ansi characters will fail (i.e. https://fa.wikipedia.org/wiki/یوآرآی)
+                    if (false === $parsed) {
+                        parent::addError($path, 'Invalid  RFC 3987 IRI format', 'format', [ 'format' => $schema->format ]);
+                    }
+
+                    $scheme = (isset($parsed['scheme'])) ? $parsed['scheme'] : null;
+
+                    // empty scheme requires host: //example.org/scheme-relative/URI/with/absolute/path/to/resource)
+                    if (!$scheme && empty($parsed['host'])) {
+                        parent::addError($path, 'Invalid  RFC 3987 IRI format', 'format', [ 'format' => $schema->format ]);
+                    }
+
+                    // urn:ISSN:1535-3613
+                    if ($scheme) {
+                        if($scheme === 'urn' && empty($parsed['path'])) {
+                            parent::addError($path, 'Invalid  RFC 3987 IRI format', 'format', [ 'format' => $schema->format ]);
+                        }
+                    }
+                }
+            break;
+
+            case 'uuid':
+                if (!Uuid::isValid($element)) {
+                    $this->addError($path, 'Invalid UUID', 'format', [ 'format' => $schema->format ]);
+                }
+            break;
+
+            default:
+                parent::check($element, $schema, $path, $i);
+            break;
+        }
+    }
+}

--- a/tests/src/xAPI/Validator.php
+++ b/tests/src/xAPI/Validator.php
@@ -1,0 +1,309 @@
+<?php
+namespace Tests\API;
+
+use Tests\TestCase;
+
+use JsonSchema;
+use JsonSchema\Constraints\Factory as JsonSchemaFactory;
+
+use API\Container;
+use API\Validator;
+use API\Validator\JsonSchema\Constraints\Factory as CustomFactory;
+use API\Validator\JsonSchema\Constraints\FormatConstraint as CustomFormatConstraint;
+
+//TODO un-clutter, migrate CustomFactory and CustomFormat tests
+
+class ValidatorTest extends TestCase
+{
+    public function testcreateSchemaValidator()
+    {
+        $factory = new JsonSchemaFactory();
+        $v =  new Validator(new Container());
+        $sv = $v->createSchemaValidator($factory);
+
+        $this->assertInstanceOf(JsonSchema\Validator::class, $sv);
+    }
+
+    //TODO re-locate to Tests\API\Validator\JsonSchema\Constraints\Factory
+    public function testCreateCustomFactory()
+    {
+        $factory = new CustomFactory();
+        $constraints = $factory->getConstraintMap();
+        $this->assertTrue(!empty($constraints));
+        // check extends justinrainbow/json-schema
+        $this->assertArrayHasKey('format', $constraints, '\API\Validator\JsonSchema\Constraints\Factory inherits constraintMap from \API\Validator\JsonSchema\Constraints\Factory');
+    }
+
+    /**
+     * @depends testCreateCustomFactory
+     */
+    //TODO re-locate to Tests\API\Validator\JsonSchema\Constraints\Factory
+    public function testCreateCustomFormatConstraint()
+    {
+        $factory = new CustomFactory();
+        $constraints = $factory->getConstraintMap();
+
+        $formatConstraint = new $constraints['format']();
+        $this->assertInstanceOf(CustomFormatConstraint::class, $formatConstraint);
+    }
+
+    /**
+     * @depends testCreateCustomFactory
+     */
+     //TODO re-locate to Tests\API\Validator\JsonSchema\Constraints\Factory
+    public function testcreateSchemaValidatorWithCustomFactory()
+    {
+        $factory = new CustomFactory();
+        $v =  new Validator(new Container());
+        $sv = $v->createSchemaValidator($factory);
+
+        $this->assertInstanceOf(JsonSchema\Validator::class, $sv);
+        // check extends justinrainbow/json-schema
+        $this->assertTrue(method_exists($sv, 'isValid'), 'instance inherits method "isValid" from \JsonSchema\Validator\Contstraint');
+    }
+
+    /**
+     * Tests JsonSchema validation is functional
+     * This might look out of scope, bu reasoning behind this it that the current JustinRainbow JSonSchema version returns zero errors (valid) if the schema is passed in empty or null
+     *
+     * @depends testCreateCustomFactory
+     */
+    public function testDefaultValidation()
+    {
+        $factory = new JsonSchemaFactory();
+        $v =  new Validator(new Container());
+        $sv = $v->createSchemaValidator($factory);
+
+        $schema = (object) [
+            "type"=>"object",
+            "properties"=> (object)[
+                "processRefund"=>(object)[
+                    "type" => "boolean"
+                ],
+                "refundAmount"=> (object)[
+                    "type" => "number"
+                ],
+                "color"=> (object)[
+                    "type" => "string",
+                    'format' => 'color'
+                ]
+            ],
+        ];
+
+        $sv->check((object)[
+            'processRefund' => true,
+            'refundAmount'=> 17,
+            'color' => 'black'
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with JsonSchema core');
+        $sv->reset();
+
+        $sv->check((object)[
+            'processRefund' => "true",
+            'refundAmount'=> 17,
+            'color' => 'black'
+        ], $schema);
+        $this->assertFalse($sv->isValid(), 'in-validates with JsonSchema core type');
+        $sv->reset();
+
+        $sv->check((object)[
+            'processRefund' => "true",
+            'refundAmount'=> 17,
+            'color' => 'invalid'
+        ], $schema);
+        $this->assertFalse($sv->isValid(), 'in-validates with JsonSchema core format');
+        $sv->reset();
+    }
+
+    /**
+     * Tests if both core and custom JsonSchema format are functional
+     * @depends testCreateCustomFactory
+     */
+    //TODO re-locate to Tests\API\Validator\JsonSchema\Constraints\FormatConstraint
+    public function testValidateCustomFormats()
+    {
+        $factory = new CustomFactory();
+        $v =  new Validator(new Container());
+        $sv = $v->createSchemaValidator($factory);
+
+        $schema = (object)[
+            'type'=>'object',
+            'properties' => (object)[
+                'iri' => (object)[
+                    'type'=>'string',
+                     'format'=>'iri'
+                ],
+                'url' => (object)[
+                    'type'=>'string',
+                    'format'=>'uri'
+                ],
+                "color"=> (object)[
+                    "type" => "string",
+                    'format' => 'color'
+                ],
+            ]
+        ];
+
+        $sv->check((object)[
+            'iri' => 'https://fa.wikipedia.org/wiki/یوآرآی',
+            'uri' => 'https://fa.wikipedia.org/wiki/%DB%8C%D9%88%D8%A2%D8%B1%D8%A2%DB%8C',
+            'color' => 'black',
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with JsonSchema core format (not affected)');
+        $sv->reset();
+
+        $sv->check((object)[
+            'iri' => 'invalid',
+            'uri' => 'https://fa.wikipedia.org/wiki/%DB%8C%D9%88%D8%A2%D8%B1%D8%A2%DB%8C',
+            'color' => 'black',
+        ], $schema);
+        $this->assertFalse($sv->isValid(), 'in-validates with custom format "iri"');
+        $sv->reset();
+    }
+
+    /**
+     * Tests custom JsonSchema format "iri" validation
+     *
+     * @depends testValidateCustomFormats
+     */
+    //TODO re-locate to Tests\API\Validator\JsonSchema\Constraints\FormatConstraint
+    public function testValidateCustomFormatConstraintIrI()
+    {
+        $factory = new CustomFactory();
+        $v =  new Validator(new Container());
+        $sv = $v->createSchemaValidator($factory);
+
+        $schema = (object)[
+            'type'=>'object',
+            'properties' => (object)[
+                'iri' => (object)[
+                    'type'=>'string',
+                     'format'=>'iri'
+                ],
+            ]
+        ];
+
+        $sv->check((object)[
+            'iri' => 'https://fa.wikipedia.org/wiki/یوآرآی',
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with custom format "iri" non-ansi uri');
+        $sv->reset();
+
+        $sv->check((object)[
+            'iri' => 'https://en.wikipedia.org/wiki/Uniform_Resource_Identifier',
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with custom format "iri" rfc2396 uri');
+        $sv->reset();
+
+        $sv->check((object)[
+            'iri' => 'http://müsic.example/motörhead',
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with JsonSchema core format (not affected)');
+        $sv->reset();
+
+        $sv->check((object)[
+            'iri' => '//example.org/scheme-relative/URI/with/absolute/path/to/resource',
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with custom format "iri" against empty uri-scheme');
+        $sv->reset();
+
+        $sv->check((object)[
+            'iri' => 'urn:ISSN:1535-3613',
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with custom format "iri" against urn');
+        $sv->reset();
+
+        $sv->check((object)[
+            'iri' => '//fa.wikipedia.org',
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with custom format "iri" against empty uri-scheme and empty path');
+        $sv->reset();
+
+        $sv->check((object)[
+            'iri' => '---',
+        ], $schema);
+        $this->assertFalse($sv->isValid(), 'in-validates invalid custom format "iri"');
+        $sv->reset();
+
+        $sv->check((object)[
+            'iri' => 23,
+        ], $schema);
+        $this->assertFalse($sv->isValid(), 'in-validates wrong type of custom format "iri"');
+        $sv->reset();
+
+        $sv->check((object)[
+            'iri' => '',
+        ], $schema);
+        $this->assertFalse($sv->isValid(), 'in-validates empty custom format "iri"');
+        $sv->reset();
+    }
+
+    /**
+     * Tests custom JsonSchema format "uuid" validation
+     *
+     * @depends testValidateCustomFormats
+     */
+    //TODO re-locate to Tests\API\Validator\JsonSchema\Constraints\FormatConstraint
+    public function testValidateCustomFormatConstraintUuid()
+    {
+        $factory = new CustomFactory();
+        $v =  new Validator(new Container());
+        $sv = $v->createSchemaValidator($factory);
+
+        $schema = (object)[
+            'type'=>'object',
+            'properties' => (object)[
+                'id' => (object)[
+                    'type'=>'string',
+                     'format'=>'uuid'
+                ],
+            ]
+        ];
+
+        ////
+        // extends tests in https://github.com/ramsey/uuid/blob/master/src/Uuid.php
+        ///
+
+        $sv->check((object)[
+            'id' => 'ff6f8cb0-c57d-11e1-9b21-0800200c9a66',
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with custom format "uuid" goodVersion1');
+        $sv->reset();
+
+        $sv->check((object)[
+            'id' => '{ff6f8cb0-c57d-11e1-9b21-0800200c9a66}',
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with custom format "uuid" {goodVersion1} (brackets)');
+        $sv->reset();
+
+        $sv->check((object)[
+            'id' => 'urn:uuid:e05aa883-acaf-40ad-bf54-02c8ce485fb0',
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with custom format "uuid" legacy urn version');
+        $sv->reset();
+
+        $sv->check((object)[
+            'id' => '{urn:uuid:e05aa883-acaf-40ad-bf54-02c8ce485fb0}',
+        ], $schema);
+        $this->assertTrue($sv->isValid(), 'validates with custom format "uuid" {legacy urn version} (brackets)');
+        $sv->reset();
+
+        $sv->check((object)[
+            'id' => 'invalid',
+        ], $schema);
+        $this->assertFalse($sv->isValid(), 'in-validates empty invalid format "uuid"');
+        $sv->reset();
+
+        $sv->check((object)[
+            'id' => [],
+        ], $schema);
+        $this->assertFalse($sv->isValid(), 'in-validates wrong type of invalid format "uuid"');
+        $sv->reset();
+
+        $sv->check((object)[
+            'id' => '',
+        ], $schema);
+        $this->assertFalse($sv->isValid(), 'in-validates empty custom format "uuid"');
+        $sv->reset();
+    }
+}

--- a/tests/src/xAPI/Validator/Validator.php
+++ b/tests/src/xAPI/Validator/Validator.php
@@ -1,0 +1,25 @@
+<?php
+namespace Tests\API\validator;
+
+use Tests\TestCase;
+
+use JsonSchema;
+use JsonSchema\Constraints\Factory as JsonSchemaFactory;
+
+use API\Container;
+use API\Validator;
+use API\Validator\JsonSchema\Constraints\Factory as CustomFactory;
+
+class ValidatorTest extends TestCase
+{
+    public function testCreateFactory()
+    {
+        $factory = new CustomFactory();
+        $v =  new Validator(new Container());
+        $sv = $v->createSchemaValidator($factory);
+
+        $this->assertInstanceOf(JsonSchema\Validator::class, $sv);
+        $this->assertInstanceOf(JsonSchema\Validator::class, $sv);
+        $this->assertTrue(method_exists($sv, 'isValid1'));
+    }
+}


### PR DESCRIPTION
as discussed in https://github.com/Brightcookie/lxHive-Internal/issues/216 and https://github.com/Brightcookie/lxHive/issues/76

Introducing custom formats for JsonSchema
 * iri
 * uuid

This is a temporary solution until the ConformanceRelease is spec-ed and implemented

uni tests:

```
$ ./vendor/bin/phpunit tests/src/xAPI/Validator.php
```
