### PR TITLE
Fix for PHP 5.x.x

### DIFF
--- a/src/xAPI/Admin/Validator.php
+++ b/src/xAPI/Admin/Validator.php
@@ -50,8 +50,12 @@ class Validator
      * @return void
      * @throws AdminException
      */
-    public function validateName(string $str)
+    public function validateName($str)
     {
+        if (!is_string($str)) {
+            throw new AdminException('Must be a string');
+        }
+
         $errors = [];
         $length = 4;
 
@@ -71,8 +75,12 @@ class Validator
      * @return void
      * @throws AdminException
      */
-    public function validatePassword(string $str)
+    public function validatePassword($str)
     {
+        if (!is_string($str)) {
+            throw new AdminException('Must be a string');
+        }
+
         $errors = [];
         $length = 8;
 
@@ -108,8 +116,12 @@ class Validator
      * @return void
      * @throws AdminException
      */
-    public function validateEmail(string $email)
+    public function validateEmail($email)
     {
+
+        if (!is_string($email)) {
+            throw new AdminException('Must be a string');
+        }
         if (!filter_var($email, \FILTER_VALIDATE_EMAIL)) {
             throw new AdminException('Invalid email address!');
         }
@@ -148,8 +160,13 @@ class Validator
      * @return void
      * @throws AdminException
      */
-    public function validateRedirectUri(string $str)
+    public function validateRedirectUri($str)
     {
+
+        if (!is_string($str)) {
+            throw new AdminException('Must be a string');
+        }
+
         $components = parse_url($str);
         if (false === $components) {
             throw new AdminException('Invalid url');
@@ -171,8 +188,13 @@ class Validator
      * @return void
      * @throws AdminException
      */
-    public function validateMongoName(string $str)
+    public function validateMongoName($str)
     {
+
+        if (!is_string($str)) {
+            throw new AdminException('Must be a string');
+        }
+
         $errors = [];
         $minLength = 4;// mongo does only require a length > 0
         $maxLength = 64;

--- a/src/xAPI/Service/Auth.php
+++ b/src/xAPI/Service/Auth.php
@@ -137,7 +137,7 @@ class Auth extends Service
         foreach($permissions as $name) {
             $merged = array_merge($merged, $this->getInheritanceFor($name));
         }
-        return array_unique($merged);
+        return $this->filterPermissions($merged);
     }
 
     /**
@@ -148,8 +148,12 @@ class Auth extends Service
      *
      * @return array inherited permissions (not including $name!)
      */
-    public function getInheritanceFor(string $name)
+    public function getInheritanceFor($name)
     {
+        // TODO 0.10.x Issue warning to logger
+        if(!is_string($name)) {
+            return [];
+        }
         if (!isset($this->scopes[$name])) {
             return [];
         }
@@ -175,8 +179,12 @@ class Auth extends Service
      *
      * @return array|false
      */
-    public function getAuthScope(string $name)
+    public function getAuthScope($name)
     {
+        // TODO 0.10.x Issue warning to logger
+        if(!is_string($name)) {
+            return false;
+        }
         return (isset($this->scopes[$name])) ? $this->scopes[$name] : false;
     }
 
@@ -185,8 +193,12 @@ class Auth extends Service
      *
      * @return bool
      */
-    public function hasPermission(string $name)
+    public function hasPermission($name)
     {
+        // TODO 0.10.x Issue warning to logger
+        if(!is_string($name)) {
+            return false;
+        }
         return in_array($name, $this->permissions);
     }
 
@@ -196,8 +208,13 @@ class Auth extends Service
      *
      * @return bool
      */
-    public function requirePermission(string $name)
+    public function requirePermission($name)
     {
+        // TODO 0.10.x Issue warning to logger
+        if(!is_string($name)) {
+            throw new \RunTimeException('requirePermission: supplied name is not a string');
+        }
+
         if (!in_array($name, $this->permissions)){
             throw new HttpException('Unauthorized', 401);
         }
@@ -231,7 +248,7 @@ class Auth extends Service
     private function filterPermissions(array $permissionNames)
     {
         $configured = array_keys($this->scopes);
-        return array_filter($permissionNames, function($name) use ($configured) {
+        $sanitized =  array_filter($permissionNames, function($name) use ($configured) {
             // TODO 0.10.x Issue warning to logger
             if(!is_string($name)) {
                 return false;
@@ -242,6 +259,7 @@ class Auth extends Service
             return in_array($name, $configured);
             // TODO 0.10.x Issue warning
         });
+        return array_values(array_unique($sanitized));
     }
 
 }

--- a/tests/src/xAPI/Admin/ValidatorTest.php
+++ b/tests/src/xAPI/Admin/ValidatorTest.php
@@ -18,6 +18,7 @@ class ValidatorTest extends TestCase
 
         $this->expectException(AdminException::class);
         $v->validateName('');
+        $v->validateName([1, 2, 3]);
         $v->validateName(false); // empty space
         $v->validateName(2);
         $v->validateName('a');
@@ -29,6 +30,7 @@ class ValidatorTest extends TestCase
         $v->validateEmail('valid@email.com');
 
         $this->expectException(AdminException::class);
+        $v->validateEmail([1, 2, 3]);
         $v->validateEmail('invalid');
         $v->validateEmail(' valid@email.com'); // empty space
         $v->validateEmail('invalid@');
@@ -40,6 +42,7 @@ class ValidatorTest extends TestCase
         $v->validatePassword('ValidPass999!');
 
         $this->expectException(AdminException::class);
+        $v->validatePassword([1, 2, 3]);
         $v->validatePassword('Val'); // too short
         $v->validatePassword('ValidPass!'); // requires number
         $v->validatePassword('ValidPass999'); // requires non alphaNumeric
@@ -67,6 +70,7 @@ class ValidatorTest extends TestCase
         $this->expectException(AdminException::class);
         $v->validateRedirectUri('');
         $v->validateRedirectUri(true);
+        $v->validatePassword([1, 2, 3]);
         $v->validateRedirectUri('invalid');
         $v->validateRedirectUri('//');
         $v->validateRedirectUri('//test');


### PR DESCRIPTION
auth/admin

- removed type hinting for non-scalar types in arguments (`string $arg`)

auth

- hardening API\Service::filterPermissions: `array_unique` preserves keys,
- sanitation for `API\Service::mergeInheritance`
- fixing tests