### PR TITLE
move twig cache folder into storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ src/xAPI/Config/*.yml
 # file storage
 storage/logs/*
 storage/files/*
-src/xAPI/View/V10/OAuth/.Cache/[A-z0-9]*
+storage/.cache/*
 cache/*
 
 # doc generator

--- a/src/xAPI/Bootstrap.php
+++ b/src/xAPI/Bootstrap.php
@@ -396,7 +396,7 @@ class Bootstrap
         $container['view'] = function ($c) {
             $view = new \Slim\Views\Twig(dirname(__FILE__).'/View/V10/OAuth/Templates', [
                 'debug' => 'true',
-                'cache' => dirname(__FILE__).'/View/V10/OAuth/Templates',
+                'cache' => Config::get('appRoot').'/storage/.cache',
             ]);
             $twigDebug = new \Twig_Extension_Debug();
             $view->addExtension($twigDebug);
@@ -413,7 +413,7 @@ class Bootstrap
             // Public routes
             if ($container['request']->getUri()->getPath() === '/about') {
                 return null;
-            }            
+            }
             if (strpos($container['request']->getUri()->getPath(), '/oauth') === 0) {
                 return null;
             }


### PR DESCRIPTION
move twig cache directory into writable storage folder 

```
{"code":500,"message":"Unable to create the cache directory (\/home\/chrx\/Workspace\/lxhive\/src\/xAPI\/View\/V10\/OAuth\/Templates\/1c).","data":[]}
```