### PR TITLE
Fix issuing temporary access tokens

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -1,2 +1,3 @@
 * Jakob Murko - @sraka1
 * Joerg Boeselt - @RoboSparrow
+* Maarten de Boer - @mdeboer

--- a/src/xAPI/Service/Auth/Basic.php
+++ b/src/xAPI/Service/Auth/Basic.php
@@ -173,7 +173,14 @@ class Basic extends Service implements AuthInterface
 
         // TODO 0.11.x: This functionality (user creation + token creation should be in two separate API calls)
         $userService = new UserService($this->getContainer());
-        $user = $userService->addUser($parsedParams->user->name, $parsedParams->user->description, $parsedParams->user->email, $parsedParams->user->password, $permissionDocuments)->toArray();
+        
+        // Fetch user or create it if it doesn't exist
+        $user = $userService->getStorage()->getUserStorage()->findByEmail($parsedParams->user->email);
+        
+        if ($user === null) {
+            $user = $userService->addUser($parsedParams->user->name, $parsedParams->user->description, $parsedParams->user->email, $parsedParams->user->password, $permissionDocuments)->toArray();
+        }
+        
         $accessTokenDocument = $this->addToken($parsedParams->name, $parsedParams->description, $expiresAt, $user, $scopeDocuments);
 
         return $accessTokenDocument;

--- a/src/xAPI/Storage/Adapter/Mongo/User.php
+++ b/src/xAPI/Storage/Adapter/Mongo/User.php
@@ -175,4 +175,19 @@ class User extends Provider implements UserInterface, SchemaInterface
 
         return $document;
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function findByEmail($username)
+    {
+        $storage = $this->getContainer()->get('storage');
+        $expression = $storage->createExpression();
+
+        $expression->where('email', $username);
+
+        $document = $storage->findOne(self::COLLECTION_NAME, $expression);
+
+        return $document;
+    }
 }


### PR DESCRIPTION
Affected version: [0.10.0](https://github.com/Brightcookie/lxHive/tree/0.10.0)
Suggested version: 0.10.1

Previously it wasn’t checked if a user existed and was always created. This caused an error on creating a temporary access token for the second time for a user. This commit fixes the problem by checking if a user exists before attempting to create it.