### PR TITLE
Fix require permissions not merging inheritance

### DIFF
--- a/src/xAPI/Service/Auth.php
+++ b/src/xAPI/Service/Auth.php
@@ -194,11 +194,13 @@ class Auth extends Service
      * Checks if a permission is set for the user auth and throws Exception
      * if queried permission is not assigned to the user auth
      *
-     * @return bool
+     * @throws HttpException when unauthorized
      */
     public function requirePermission(string $name)
     {
-        if (!in_array($name, $this->permissions)){
+        $permissions = $this->mergeInheritance($this->permissions);
+        
+        if (!in_array($name, $permissions)){
             throw new HttpException('Unauthorized', 401);
         }
 
@@ -206,7 +208,6 @@ class Auth extends Service
         if (!isset($this->scopes[$name])){
             throw new HttpException('Unauthorized', 401);
         }
-
     }
 
     /**


### PR DESCRIPTION
Affected version: 0.10.0

The requirePermissions method did not merge inherited permissions before checking the required permission.

For example requiring the "state" permission for a client which has the "all" permission set (which inherits "state") always threw a 401 Unauthorised.